### PR TITLE
change <= for <

### DIFF
--- a/lib/Tumblr/StreamBuilder/Streams/ChronologicalStreamMixer.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ChronologicalStreamMixer.php
@@ -118,7 +118,8 @@ final class ChronologicalStreamMixer extends StreamMixer
                 throw new \UnexpectedValueException('Unexpected value for sorting option. Options: asc or desc');
             }
         });
-        return new StreamResult(count($res) <= $count, array_slice($res, 0, $count));
+        $elements = array_slice($res, 0, $count);
+        return new StreamResult(count($elements) < $count, $elements);
     }
 
     /**


### PR DESCRIPTION
the flag for no more results should be true when the amount of elements is less than requested

See: (issue #)

### What and why? 🤔

there might be more elements after the last one in the `$res` array.


### Testing Steps ✍️

Code review

### You're it! 👑

@Automattic/stream-builders
