### PR TITLE
allow fencepost cursor to return null

### DIFF
--- a/lib/Tumblr/StreamBuilder/FencepostRanking/FencepostCursor.php
+++ b/lib/Tumblr/StreamBuilder/FencepostRanking/FencepostCursor.php
@@ -122,7 +122,7 @@ final class FencepostCursor extends StreamCursor
     }
 
     /**
-     * @return StreamCursor
+     * @return StreamCursor|null
      */
     public function get_tail_cursor(): StreamCursor
     {

--- a/lib/Tumblr/StreamBuilder/FencepostRanking/FencepostCursor.php
+++ b/lib/Tumblr/StreamBuilder/FencepostRanking/FencepostCursor.php
@@ -124,7 +124,7 @@ final class FencepostCursor extends StreamCursor
     /**
      * @return StreamCursor|null
      */
-    public function get_tail_cursor(): StreamCursor
+    public function get_tail_cursor(): ?StreamCursor
     {
         return $this->tail_cursor;
     }


### PR DESCRIPTION


### What and why? 🤔

We are seeing an error on tumblr caused by this cursor being null. 
We are working on the tumblr repo to work around this value being null, but we also need to patch this part of the code. 


### Testing Steps ✍️

Code review.

### You're it! 👑

#Automattic/stream-builders 
cc: @nicola-barbieri
