### PR TITLE
Throw only one exception for streamcursor:decode

### DIFF
--- a/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursor.php
+++ b/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursor.php
@@ -254,10 +254,6 @@ abstract class StreamCursor extends Templatable
                     }
                 } catch (\Exception $e) {
                     $exception = $e;
-
-                    // we might encounter more than one exception, we want to log them all.
-                    $log = StreamBuilder::getDependencyBag()->getLog();
-                    $log->exception($e);
                 }
             }
         }


### PR DESCRIPTION
### What and why? 🤔
The StreamCursor::decode function has an inner loop
```
foreach ($encrypt_keys as $encrypt_key) {
            foreach ($encrypt_seeds as $encrypt_seed) {
       ... detect codec
      ... try to decode
     ... return cursor if decode was successful
     ... otherwise continue with the next seed/key
   }
}
```
In the current implementation we are logging an exception if a specific encrypt_key/encrypt_seed fails, while this could happen legitimately.

This PR changes the reporting of the error: we throw the last error only if we can't successfully decode the cursor string.
The exception will be then logged by StreamCursorSerializer.  

### Testing Steps ✍️

Code review should suffice. 

### You're it! 👑

@Automattic/stream-builders