### PR TITLE
Fix division by zero in WeightedRandomStreamRanker

### DIFF
--- a/lib/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRanker.php
+++ b/lib/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRanker.php
@@ -51,14 +51,23 @@ class WeightedRandomStreamRanker extends StreamRanker
         foreach ($valid_elements as $element) {
             /** @var RecommendationLeafStreamElementTrait $original_element */
             $original_element = $element->get_original_element();
-            if ($original_element->get_score() === 0.0) {
-                $r = 0;
-            } else {
-                // calculate sampling score
-                $r = pow(mt_rand() / $max_rand, (1 / $original_element->get_score()));
+            $score = $original_element->get_score();
+            if ($score == 0.0) {
+                $score = 0.001;
             }
-            $H[strval($r)] = $element;
+            // calculate sampling score
+            $r = pow(mt_rand() / $max_rand, (1 / $score));
+
+            // store the element in $H, using $r as key.
+            $key = strval($r);
+            if (array_key_exists($key, $H)) {
+                // We don't want to replace an element that was previously added to $H.
+                // so we append the element id, if the key already exists.
+                $key = sprintf('%s_%s', $key, $original_element->get_element_id());
+            }
+            $H[$key] = $element;
         }
+
         // sort by key in descending order
         krsort($H);
         $ranked_elements = array_values($H);

--- a/lib/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRanker.php
+++ b/lib/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRanker.php
@@ -51,8 +51,12 @@ class WeightedRandomStreamRanker extends StreamRanker
         foreach ($valid_elements as $element) {
             /** @var RecommendationLeafStreamElementTrait $original_element */
             $original_element = $element->get_original_element();
-            // calculate sampling score
-            $r = pow(mt_rand() / $max_rand, (1 / $original_element->get_score()));
+            if ($original_element->get_score() === 0.0) {
+                $r = 0;
+            } else {
+                // calculate sampling score
+                $r = pow(mt_rand() / $max_rand, (1 / $original_element->get_score()));
+            }
             $H[strval($r)] = $element;
         }
         // sort by key in descending order

--- a/lib/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRanker.php
+++ b/lib/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRanker.php
@@ -46,24 +46,17 @@ class WeightedRandomStreamRanker extends StreamRanker
 
         // weighted sampling array, $H: ['sampling score' => $stream_element]
         $H = [];
-        $max_rand = mt_getrandmax();
         /** @var StreamElement $element */
         foreach ($valid_elements as $element) {
-            /** @var RecommendationLeafStreamElementTrait $original_element */
-            $original_element = $element->get_original_element();
-            $score = $original_element->get_score();
-            if ($score == 0.0) {
-                $score = 0.001;
-            }
             // calculate sampling score
-            $r = pow(mt_rand() / $max_rand, (1 / $score));
+            $r = $this->get_element_random_score($element);
 
             // store the element in $H, using $r as key.
             $key = strval($r);
             if (array_key_exists($key, $H)) {
                 // We don't want to replace an element that was previously added to $H.
                 // so we append the element id, if the key already exists.
-                $key = sprintf('%s_%s', $key, $original_element->get_element_id());
+                $key = sprintf('%s_%s', $key, $element->get_element_id());
             }
             $H[$key] = $element;
         }
@@ -72,6 +65,23 @@ class WeightedRandomStreamRanker extends StreamRanker
         krsort($H);
         $ranked_elements = array_values($H);
         return array_merge($ranked_elements, $not_valid_elements);
+    }
+
+    /**
+     * @param StreamElement $element Stream element to rank randomly
+     * @return float|int|object
+     */
+    protected function get_element_random_score(StreamElement $element)
+    {
+        /** @var RecommendationLeafStreamElementTrait $original_element */
+        $original_element = $element->get_original_element();
+        $max_rand = mt_getrandmax();
+        $score = $original_element->get_score();
+        if ($score == 0.0) {
+            $score = 0.001;
+        }
+        // calculate sampling score
+        return pow(mt_rand() / $max_rand, (1 / $score));
     }
 
     /**

--- a/tests/unit/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRankerTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRankerTest.php
@@ -112,9 +112,6 @@ class WeightedRandomStreamRankerTest extends \PHPUnit\Framework\TestCase
         $ranked_elements = $this->ranker->rank($stream_elements);
         mt_srand(0);
         $weighted_score = array_map(function ($score) {
-            if ($score === 0.0) {
-                return 0;
-            }
             return pow(mt_rand() / mt_getrandmax(), (1 / $score));
         }, $bid2score);
         // sort by value in descending order

--- a/tests/unit/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRankerTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRankerTest.php
@@ -112,7 +112,9 @@ class WeightedRandomStreamRankerTest extends \PHPUnit\Framework\TestCase
         $ranked_elements = $this->ranker->rank($stream_elements);
         mt_srand(0);
         $weighted_score = array_map(function ($score) {
-            if ($score === 0.0) return 0;
+            if ($score === 0.0) {
+                return 0;
+            }
             return pow(mt_rand() / mt_getrandmax(), (1 / $score));
         }, $bid2score);
         // sort by value in descending order

--- a/tests/unit/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRankerTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRankerTest.php
@@ -105,12 +105,14 @@ class WeightedRandomStreamRankerTest extends \PHPUnit\Framework\TestCase
             1234 => 1.0,
             2345 => 2.0,
             3456 => 3.0,
+            4567 => 0.0,
         ];
         $stream_elements = $this->build_blog_stream_elements($bid2score);
         mt_srand(0);
         $ranked_elements = $this->ranker->rank($stream_elements);
         mt_srand(0);
         $weighted_score = array_map(function ($score) {
+            if ($score === 0.0) return 0;
             return pow(mt_rand() / mt_getrandmax(), (1 / $score));
         }, $bid2score);
         // sort by value in descending order


### PR DESCRIPTION
### What and why? 🤔

There's a division by zero bug in `WeightedRandomStreamRanker` when the score for an element is zero. This PR fixes that.

### Testing Steps ✍️

A code review, and ensuring tests pass is fine in this case.

### You're it! 👑

@Automattic/stream-builders 
