### PR TITLE
Documentation: Fix mistake in Ranker example YAML

### DIFF
--- a/docs/StreamBuilder-Beginners-Guide.md
+++ b/docs/StreamBuilder-Beginners-Guide.md
@@ -460,7 +460,8 @@ stream_filter:
     - _type: Component\Trending\StreamBuilder\StreamFilters\EmptyTopicStreamElement
 stream:
   _type: Tumblr\StreamBuilder\Streams\RankedStream
-  ranker: Tumblr\StreamBuilder\StreamRankers\RandomRanker
+  ranker: 
+    _type: Tumblr\StreamBuilder\StreamRankers\RandomRanker
   inner:
     _type: Component\Trending\StreamBuilder\Streams\TrendingTopicStream
 ```


### PR DESCRIPTION
### What and why? 🤔

Minor Beginner's Guide update:

The Beginner's Guide has the following example template for `StreamRanker`

```
_type: Tumblr\StreamBuilder\Streams\FilteredStream
stream_filter:
  _type: Tumblr\StreamBuilder\StreamFilters\CompositeStreamFilter
  stream_filter_array:
    - _type: Component\Trending\StreamBuilder\StreamFilters\EmptyTopicStreamElement
stream:
  _type: Tumblr\StreamBuilder\Streams\RankedStream
  ranker: Tumblr\StreamBuilder\StreamRankers\RandomRanker
  inner:
    _type: Component\Trending\StreamBuilder\Streams\TrendingTopicStream
```

The line

```
  ranker: Tumblr\StreamBuilder\StreamRankers\RandomRanker
```

should actually be

```
  ranker: 
    _type: Tumblr\StreamBuilder\StreamRankers\RandomRanker
```

Trying to have a `ranker:` definition without the `_type` causes a `Uncaught TypeError: Tumblr\StreamBuilder\StreamContext::derive(): Argument #1 ($template) must be of type ?array, string given` exception.

### Testing Steps ✍️

NA

### You're it! 👑

@Automattic/stream-builders 
