### PR TITLE
Make example app require a fully qualified path

### DIFF
--- a/example/index.php
+++ b/example/index.php
@@ -20,7 +20,7 @@
  */
 
 // require our app bootstrap, which includes StreamBuilder
-require_once 'src/Automattic/MyAwesomeReader/bootstrap.php';
+require_once __DIR__ . '/src/Automattic/MyAwesomeReader/bootstrap.php';
 
 // init our application
 $app = new \Automattic\MyAwesomeReader\App();


### PR DESCRIPTION
### What and why? 🤔

By making the require in the example app a fully qualified path, we avoid a linting error on deploy in WPCOM and won't affect anyone else.

### Testing Steps ✍️

Visual inspection

### You're it! 👑

@Automattic/stream-builders
