### PR TITLE
Remove non-code files from release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 /tests                export-ignore
 /example              export-ignore
 /extras               export-ignore
+/config               export-ignore
 
 # Test with:
 # git archive --format=tar HEAD | tar t

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.*                   export-ignore
+/Makefile             export-ignore
+/*.dist               export-ignore
+/psalm.xml            export-ignore
+/tests                export-ignore
+
+# Test with:
+# git archive --format=tar HEAD | tar t

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,10 @@
 /.*                   export-ignore
 /Makefile             export-ignore
 /*.dist               export-ignore
-/psalm.xml            export-ignore
+/phpcs.xml            export-ignore
 /tests                export-ignore
+/example              export-ignore
+/extras               export-ignore
 
 # Test with:
 # git archive --format=tar HEAD | tar t

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ StreamBuilder expects PHP 7.4+.
 
 Install StreamBuilder by using [Composer](https://getcomposer.org/) and running `composer require automattic/stream-builder` in your project.
 
+To access the examples and unit tests, please use `composer require --prefer-source automattic/stream-builder` to make a local git clone.
+
 ## Contributing
 
 If you want to change the StreamBuilder code, please:

--- a/docs/StreamBuilder-Beginners-Guide.md
+++ b/docs/StreamBuilder-Beginners-Guide.md
@@ -54,7 +54,7 @@ As an example of how to use StreamBuilder, we will implement an endpoint to retr
 
 Let's also assume the returned array is a simple `string[]` which contains trending topics as strings.
 
-We also have an example demo application in the `example/` folder which implements a lot of what we're going to discuss here -- so check that out!
+We also have an example demo application in the `example/` folder which implements a lot of what we're going to discuss here -- so check that out! You must clone the Git repository to work with the example, as released archives do not include example code.
 
 ### Integrating StreamBuilder with your codebase
 

--- a/example/README.md
+++ b/example/README.md
@@ -2,7 +2,7 @@
 
 This is an example app of MyAwesomeReader implementing StreamBuilder.
 
-Please note this example isn't bundled with the distribution archive: please make a local git clone.
+Please note this example isn't bundled with the released archives: please make a local git clone.
 
 In this example, we implement an endpoint for trending topics that uses a `Stream`, `StreamElement`, and a `Cursor`.
 

--- a/example/README.md
+++ b/example/README.md
@@ -2,6 +2,8 @@
 
 This is an example app of MyAwesomeReader implementing StreamBuilder.
 
+Please note this example isn't bundled with the distribution archive: please make a local git clone.
+
 In this example, we implement an endpoint for trending topics that uses a `Stream`, `StreamElement`, and a `Cursor`.
 
 Usage is:


### PR DESCRIPTION
See: #24 

### What and why? 🤔

To avoid problems such as in https://github.com/Automattic/stream-builder/pull/24 let's exclude all non-library files (examples, tests, plumbing) from the final release archive.

### Testing Steps ✍️

`git archive --format=tar HEAD | tar t` should get you a list of included files, which should not include tests and examples.

For a summary, see:

```
$ git archive --format=tar HEAD | tar t | cut -f1 -d/ | sort | uniq
composer.json
config
docs
lib
LICENSE
README.md
```

### You're it! 👑

@Automattic/stream-builders
