### PR TITLE
[bug] The cursor_size logger is misleading

### DIFF
--- a/lib/Tumblr/StreamBuilder/Codec/BinaryCodec.php
+++ b/lib/Tumblr/StreamBuilder/Codec/BinaryCodec.php
@@ -103,9 +103,15 @@ final class BinaryCodec extends Codec
     /**
      * @inheritDoc
      */
-    public function encode(Templatable $obj): string
+    public function encode($obj): string
     {
-        $json = Helpers::json_encode($obj->to_template());
+        if ($obj instanceof Templatable) {
+            $json = Helpers::json_encode($obj->to_template());
+        } elseif (is_string($obj)) {
+            $json = $obj;
+        } else {
+            throw new \InvalidArgumentException(sprintf("%s type is not supported", get_class($obj)));
+        }
         $compressed = gzdeflate($json);
         $encrypted = openssl_encrypt($compressed, self::CIPHER, $this->encrypt_key, 0, $this->initial_vector);
         $signature = $this->compute_signature($encrypted);

--- a/lib/Tumblr/StreamBuilder/Codec/CacheCodec.php
+++ b/lib/Tumblr/StreamBuilder/Codec/CacheCodec.php
@@ -42,6 +42,12 @@ final class CacheCodec extends Codec
     public const SERIALIZATION_TYPE_JSON = 'JSON';
 
     /**
+     * Cache content from a serialized JSON object
+     * @var string
+     */
+    public const SERIALIZATION_TYPE_JSON_STRING = 'JSON_STRING';
+
+    /**
      * Cache content serialized/deserialized by doing serialize/unserialize
      * @var string
      */
@@ -80,11 +86,14 @@ final class CacheCodec extends Codec
     /**
      * @inheritDoc
      */
-    public function encode(Templatable $obj): string
+    public function encode($obj): string
     {
         switch ($this->serialization_type) {
             case self::SERIALIZATION_TYPE_JSON:
                 $serialized = Helpers::json_encode($obj->to_template());
+                break;
+            case self::SERIALIZATION_TYPE_JSON_STRING:
+                $serialized = $obj;
                 break;
             case self::SERIALIZATION_TYPE_PHP_OBJECT:
                 $serialized = serialize($obj);

--- a/lib/Tumblr/StreamBuilder/Codec/CacheCodec.php
+++ b/lib/Tumblr/StreamBuilder/Codec/CacheCodec.php
@@ -42,7 +42,7 @@ final class CacheCodec extends Codec
     public const SERIALIZATION_TYPE_JSON = 'JSON';
 
     /**
-     * Cache content from a serialized JSON object
+     * Cache content from an already-serialized string of JSON.
      * @var string
      */
     public const SERIALIZATION_TYPE_JSON_STRING = 'JSON_STRING';

--- a/lib/Tumblr/StreamBuilder/Codec/Codec.php
+++ b/lib/Tumblr/StreamBuilder/Codec/Codec.php
@@ -81,11 +81,11 @@ abstract class Codec
     }
 
     /**
-     * Encode a templatable object.
-     * @param Templatable $obj The object to encode.
+     * Encode an object.
+     * @param mixed $obj The object to encode.
      * @return string The encoded bytes string.
      */
-    abstract public function encode(Templatable $obj): string;
+    abstract public function encode($obj): string;
 
     /**
      * Decode an encoded templatable object.

--- a/lib/Tumblr/StreamBuilder/Codec/Codec.php
+++ b/lib/Tumblr/StreamBuilder/Codec/Codec.php
@@ -82,7 +82,7 @@ abstract class Codec
 
     /**
      * Encode an object.
-     * @param mixed $obj The object to encode.
+     * @param Templatable|string $obj The object to encode, or pre-encoded object.
      * @return string The encoded bytes string.
      */
     abstract public function encode($obj): string;

--- a/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursor.php
+++ b/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursor.php
@@ -171,7 +171,8 @@ abstract class StreamCursor extends Templatable
             $current_user_id
         );
 
-        $encoded = $binary_codec->encode($cursor);
+        $json = Helpers::json_encode($cursor->to_template());
+        $encoded = $binary_codec->encode($json);
         $encoded = Helpers::base64UrlEncode($encoded);
 
         $cursor_size = strlen($encoded);
@@ -183,16 +184,16 @@ abstract class StreamCursor extends Templatable
             $cache_codec = new CacheCodec(
                 $cache_provider,
                 CacheProvider::OBJECT_TYPE_CURSOR,
-                CacheCodec::SERIALIZATION_TYPE_JSON
+                CacheCodec::SERIALIZATION_TYPE_JSON_STRING
             );
-            $encoded = $cache_codec->encode($cursor);
+            $encoded = $cache_codec->encode($json);
             // base64 url encode cache encoded as well, to line up with binary codec encoded logic.
             $encoded = Helpers::base64UrlEncode($encoded);
 
             // This is an implementation detail, but the CacheCodec does not base64 encode the payload before
             // writing to cache, so the original cursor_size is misleading. Base64 encoding can increase the
             // payload size by 33%.
-            $cursor_size = strlen(Helpers::json_encode($cursor->to_template()));
+            $cursor_size = strlen($json);
         }
 
         StreamBuilder::getDependencyBag()->getLog()

--- a/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursor.php
+++ b/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursor.php
@@ -189,8 +189,10 @@ abstract class StreamCursor extends Templatable
             // base64 url encode cache encoded as well, to line up with binary codec encoded logic.
             $encoded = Helpers::base64UrlEncode($encoded);
 
-            // Update the cursor size
-            $cursor_size = strlen($encoded);
+            // This is an implementation detail, but the CacheCodec does not base64 encode the payload before
+            // writing to cache, so the original cursor_size is misleading. Base64 encoding can increase the
+            // payload size by 33%.
+            $cursor_size = strlen(Helpers::json_encode($cursor->to_template()));
         }
 
         StreamBuilder::getDependencyBag()->getLog()

--- a/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursor.php
+++ b/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursor.php
@@ -176,8 +176,6 @@ abstract class StreamCursor extends Templatable
 
         $cursor_size = strlen($encoded);
         $context = $context ?? 'unknown';
-        StreamBuilder::getDependencyBag()->getLog()
-            ->histogramTick('cursor_size', $context, ($cursor_size / 1000.0));
 
         if (($cache_provider instanceof CacheProvider) && ($cursor_size > $cache_size_threshold)) {
             StreamBuilder::getDependencyBag()->getLog()
@@ -190,7 +188,13 @@ abstract class StreamCursor extends Templatable
             $encoded = $cache_codec->encode($cursor);
             // base64 url encode cache encoded as well, to line up with binary codec encoded logic.
             $encoded = Helpers::base64UrlEncode($encoded);
+
+            // Update the cursor size
+            $cursor_size = strlen($encoded);
         }
+
+        StreamBuilder::getDependencyBag()->getLog()
+            ->histogramTick('cursor_size', $context, ($cursor_size / 1000.0));
 
         return $encoded;
     }


### PR DESCRIPTION
See: (issue #)

### What and why? 🤔

In the StreamCursor, the serialization logic attempts to use the BinaryCodec, but if the size exceeds some threshold (1800 bytes), it instead uses the CachedCodec. The CachedCodec will return a cache key and write the payload to cache behind-the-scenes.

The stats that are published represent the size of the BinaryCodec payload but does not account for the case where the CachedCodec is used. There is also a slight discrepancy, where the CachedCodec writes the payload as a plain JSON without base-64 url encoding, so the published stats could be inflated up to 33%: https://www.php.net/manual/en/function.base64-encode.php

This implementation also modifies the encode function to accept a serialized JSON string so that we wouldn't need to call `->to_template()` multiple times. We already call it two times when the CachedCodec is used, without this change, we would need to call ->to_template() three times, so this should be an improvement.

It is also worth noting that the current API where encode takes in an Templatable is not respected because if the CachedCodec serialization type is `SERIALIZATION_TYPE_PHP_OBJECT`, the input wouldn't be a Templatable, so changing it from `encode(Templatable $obj)` -> `encode(mixed $obj)` is more accurate anyways..

### Testing Steps ✍️

> Can add tests if there's agreement that this change is worth making

Provide adequate testing steps (including examples if necessary).
Don't assume someone knows how to test your changes; be thorough.

- [ ] Bullet point checklists
- [ ] Are useful for some tests

### You're it! 👑

Tag a random reviewer by adding `@Automattic/stream-builders` to the reviewers section, but mention them here for visibility as well.
