### PR TITLE
PHP 8.1 compatibility updates

### DIFF
--- a/extras/phpcs/PHPCSDiff.php
+++ b/extras/phpcs/PHPCSDiff.php
@@ -118,8 +118,8 @@ class PHPCSDiff
 
     /**
      * @param $phpcbf_path - Path the the PHPCS binary/phar/command
-     * @param null $phpcs_standard - The PHPCS standard to use
-     * @param bool|true $allow_fix - Offer to autofix the violatingfile
+	 * @param null $phpcs_standard - The PHPCS standard to use
+	 * @param bool|true $allow_fix - Offer to autofix the violatingfile
      * @param bool $non_interactive True for non-interactive mode, false for interactive mode
      */
     public function __construct($phpcbf_path, $phpcs_standard = null, $allow_fix = true, bool $non_interactive = false)
@@ -131,8 +131,8 @@ class PHPCSDiff
     }
 
     /**
-     * Adds an outputter to the outputter stack
-     *
+	 * Adds an outputter to the outputter stack
+	 *
      * @param OutputterInterface $outputter
      */
     public function addOutputter(OutputterInterface $outputter)

--- a/extras/phpcs/PHPCSDiff.php
+++ b/extras/phpcs/PHPCSDiff.php
@@ -334,7 +334,7 @@ class PHPCSDiff
         if (!isset($data['files']) || !is_array($data['files']) || count($data['files']) < 1) {
             return [];
         }
-        if (is_array($data['files']) && count($data['files']) > 1) {
+        if (count($data['files']) > 1) {
             throw new \InvalidArgumentException(
                 'getErrors only works with a single file, ' . count($data['files']) . ' given'
             );

--- a/extras/phpcs/PHPCSDiff.php
+++ b/extras/phpcs/PHPCSDiff.php
@@ -331,10 +331,10 @@ class PHPCSDiff
     protected function getErrors(array $data, string $type = 'ERROR'): array
     {
         $errors = [];
-        if (!isset($data['files']) || count($data['files']) < 1) {
+        if (!isset($data['files']) || !is_array($data['files']) || count($data['files']) < 1) {
             return [];
         }
-        if (count($data['files']) > 1) {
+        if (is_array($data['files']) && count($data['files']) > 1) {
             throw new \InvalidArgumentException(
                 'getErrors only works with a single file, ' . count($data['files']) . ' given'
             );

--- a/extras/phpcs/TumblrApp/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/extras/phpcs/TumblrApp/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -416,12 +416,12 @@ class ArrayDeclarationSniff implements Sniff
             if ($tokens[$nextToken]['code'] === T_COMMA) {
                 $stackPtrCount = 0;
                 if (isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
-                    $stackPtrCount = count($tokens[$stackPtr]['nested_parenthesis']);
+                    $stackPtrCount = is_countable($tokens[$stackPtr]['nested_parenthesis']) ? count($tokens[$stackPtr]['nested_parenthesis']) : 0;
                 }
 
                 $commaCount = 0;
                 if (isset($tokens[$nextToken]['nested_parenthesis']) === true) {
-                    $commaCount = count($tokens[$nextToken]['nested_parenthesis']);
+                    $commaCount = is_countable($tokens[$nextToken]['nested_parenthesis']) ? count($tokens[$nextToken]['nested_parenthesis']) : 0;
                     if ($tokens[$stackPtr]['code'] === T_ARRAY) {
                         // Remove parenthesis that are used to define the array.
                         $commaCount--;

--- a/extras/phpcs/TumblrApp/Sniffs/Base/RegExp.php
+++ b/extras/phpcs/TumblrApp/Sniffs/Base/RegExp.php
@@ -49,7 +49,7 @@ abstract class RegExp implements \PHP_CodeSniffer\Sniffs\Sniff
         if (static::SINGLE_LINE) {
             $tokens = $phpcsFile->getTokens();
             $line = $tokens[$start]['line'];
-            $length = count($tokens);
+            $length = is_countable($tokens) ? count($tokens) : 0;
             $token_length = 1;
             for ($i = $stackPtr + 1; $i < $length; $i++) {
                 if ($tokens[$i]['line'] > $line) {

--- a/extras/phpcs/TumblrApp/Sniffs/Files/LeadingWhitespaceSniff.php
+++ b/extras/phpcs/TumblrApp/Sniffs/Files/LeadingWhitespaceSniff.php
@@ -26,7 +26,8 @@ class LeadingWhitespaceSniff implements Sniff
         $tokens = $phpcsFile->getTokens();
 
         $whitespace_before_open_tag = "";
-        for ($i = 0, $len = count($tokens); $i < $len; $i++) {
+		$token_count = is_countable($tokens) ? count($tokens) : 0;
+        for ($i = 0, $len = $token_count; $i < $len; $i++) {
             $token = $tokens[$i];
             if ($token["code"] === T_OPEN_TAG) {
                 break;

--- a/extras/phpcs/TumblrApp/Sniffs/Formatting/CurlynewlineSniff.php
+++ b/extras/phpcs/TumblrApp/Sniffs/Formatting/CurlynewlineSniff.php
@@ -54,7 +54,6 @@ class CurlyNewlineSniff implements \PHP_CodeSniffer\Sniffs\Sniff
         $has_body = false;
 		$token_count = is_countable($tokens) ? count($tokens) : 0;
         for ($i = $curly + 1; $i < $token_count; $i++) {
-
             // If we make it to the closing curly, stop
             if ($i >= $tokens[$curly]['scope_closer']) {
                 break;

--- a/extras/phpcs/TumblrApp/Sniffs/Formatting/CurlynewlineSniff.php
+++ b/extras/phpcs/TumblrApp/Sniffs/Formatting/CurlynewlineSniff.php
@@ -53,7 +53,7 @@ class CurlyNewlineSniff implements \PHP_CodeSniffer\Sniffs\Sniff
         // Ensure we don't have an empty class/method
         $has_body = false;
 		$token_count = is_countable($tokens) ? count($tokens) : 0;
-        for ($i = $curly+1; $i < $token_count; $i++) {
+        for ($i = $curly + 1; $i < $token_count; $i++) {
 
             // If we make it to the closing curly, stop
             if ($i >= $tokens[$curly]['scope_closer']) {

--- a/extras/phpcs/TumblrApp/Sniffs/Formatting/CurlynewlineSniff.php
+++ b/extras/phpcs/TumblrApp/Sniffs/Formatting/CurlynewlineSniff.php
@@ -52,7 +52,8 @@ class CurlyNewlineSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 
         // Ensure we don't have an empty class/method
         $has_body = false;
-        for ($i = $curly+1; $i < count($tokens); $i++) {
+		$token_count = is_countable($tokens) ? count($tokens) : 0;
+        for ($i = $curly+1; $i < $token_count; $i++) {
 
             // If we make it to the closing curly, stop
             if ($i >= $tokens[$curly]['scope_closer']) {

--- a/lib/Tumblr/StreamBuilder/StreamSerializer.php
+++ b/lib/Tumblr/StreamBuilder/StreamSerializer.php
@@ -52,7 +52,7 @@ final class StreamSerializer
     public static function from_template(StreamContext $context): Templatable
     {
         $template = $context->get_template();
-        if (empty($template) || !key_exists('_type', $template) || !method_exists($template['_type'], 'from_template')) {
+        if (empty($template) || !array_key_exists('_type', $template) || !method_exists($template['_type'], 'from_template')) {
             throw new InvalidStreamArrayException($template);
         }
         /** @var Templatable $object */

--- a/tests/unit/Tumblr/StreamBuilder/StreamResultTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamResultTest.php
@@ -73,7 +73,7 @@ class StreamResultTest extends \PHPUnit\Framework\TestCase
     {
         $stream_result = new StreamResult(false, $this->stream_elements);
         $got_elements = $stream_result->get_elements();
-		$element_count = is_countable($got_elements) ? count($got_elements) : 0;
+        $element_count = is_countable($got_elements) ? count($got_elements) : 0;
         $this->assertSame(2, $element_count);
     }
 
@@ -90,7 +90,7 @@ class StreamResultTest extends \PHPUnit\Framework\TestCase
         $el2 = new DerivedStreamElement($el1, 'tester');
         $result = new StreamResult(false, [$el2]);
         $elements = $result->get_original_elements();
-		$element_count = is_countable($elements) ? count($elements) : 0;
+        $element_count = is_countable($elements) ? count($elements) : 0;
         $this->assertSame(1, $element_count);
         $this->assertSame(DerivedStreamElement::class, get_class($result->get_element_at_index(0)));
         $this->assertStringStartsWith('Mock_StreamElement_', get_class($elements[0]));

--- a/tests/unit/Tumblr/StreamBuilder/StreamResultTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamResultTest.php
@@ -73,7 +73,8 @@ class StreamResultTest extends \PHPUnit\Framework\TestCase
     {
         $stream_result = new StreamResult(false, $this->stream_elements);
         $got_elements = $stream_result->get_elements();
-        $this->assertSame(2, count($got_elements));
+		$element_count = is_countable($got_elements) ? count($got_elements) : 0;
+        $this->assertSame(2, $element_count);
     }
 
     /**
@@ -89,7 +90,8 @@ class StreamResultTest extends \PHPUnit\Framework\TestCase
         $el2 = new DerivedStreamElement($el1, 'tester');
         $result = new StreamResult(false, [$el2]);
         $elements = $result->get_original_elements();
-        $this->assertSame(1, count($elements));
+		$element_count = is_countable($elements) ? count($elements) : 0;
+        $this->assertSame(1, $element_count);
         $this->assertSame(DerivedStreamElement::class, get_class($result->get_element_at_index(0)));
         $this->assertStringStartsWith('Mock_StreamElement_', get_class($elements[0]));
 

--- a/tests/unit/Tumblr/StreamBuilder/Streams/ConcatenatedStreamTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/Streams/ConcatenatedStreamTest.php
@@ -118,8 +118,8 @@ class ConcatenatedStreamTest extends \PHPUnit\Framework\TestCase
     {
         $stream_field = (new ReflectionClass(get_class($this->concatenated_stream)))->getProperty("streams");
         $stream_field->setAccessible(true);
-		$value = $stream_field->getValue($this->concatenated_stream);
-		$value_count = is_countable($value) ? count($value) : 0;
+        $value = $stream_field->getValue($this->concatenated_stream);
+        $value_count = is_countable($value) ? count($value) : 0;
         $this->assertSame(3, $value_count);
     }
 
@@ -131,8 +131,8 @@ class ConcatenatedStreamTest extends \PHPUnit\Framework\TestCase
         $concatenated_stream = new ConcatenatedStream([$this->stream1, $this->stream2, $this->stream3, $this->null_stream], "concatenatedStream2");
         $stream_field = (new ReflectionClass(get_class($concatenated_stream)))->getProperty("streams");
         $stream_field->setAccessible(true);
-		$value = $stream_field->getValue($this->concatenated_stream);
-		$value_count = is_countable($value) ? count($value) : 0;
+        $value = $stream_field->getValue($this->concatenated_stream);
+        $value_count = is_countable($value) ? count($value) : 0;
         $this->assertSame(3, $value_count);
     }
 

--- a/tests/unit/Tumblr/StreamBuilder/Streams/ConcatenatedStreamTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/Streams/ConcatenatedStreamTest.php
@@ -118,7 +118,9 @@ class ConcatenatedStreamTest extends \PHPUnit\Framework\TestCase
     {
         $stream_field = (new ReflectionClass(get_class($this->concatenated_stream)))->getProperty("streams");
         $stream_field->setAccessible(true);
-        $this->assertSame(3, count($stream_field->getValue($this->concatenated_stream)));
+		$value = $stream_field->getValue($this->concatenated_stream);
+		$value_count = is_countable($value) ? count($value) : 0;
+        $this->assertSame(3, $value_count);
     }
 
     /**
@@ -129,7 +131,9 @@ class ConcatenatedStreamTest extends \PHPUnit\Framework\TestCase
         $concatenated_stream = new ConcatenatedStream([$this->stream1, $this->stream2, $this->stream3, $this->null_stream], "concatenatedStream2");
         $stream_field = (new ReflectionClass(get_class($concatenated_stream)))->getProperty("streams");
         $stream_field->setAccessible(true);
-        $this->assertSame(3, count($stream_field->getValue($concatenated_stream)));
+		$value = $stream_field->getValue($this->concatenated_stream);
+		$value_count = is_countable($value) ? count($value) : 0;
+        $this->assertSame(3, $value_count);
     }
 
     /**


### PR DESCRIPTION
See: https://github.com/Automattic/wp-calypso/issues/83721

### What and why? 🤔

This makes some minor updates for PHP 8.1 compatibility. This is part of a larger Automattic initiative to get the WPCOM codebase and all libraries used ready for migrating to PHP 8.x.

More discussion in p1698769503301209-slack-C05MFVC6L74

### Testing Steps ✍️

- Visual inspection of changes
- Run unit tests

### You're it! 👑

@sanmai 