### PR TITLE
implement release_all_elements method on StreamTracer

### DIFF
--- a/lib/Tumblr/StreamBuilder/StreamFilters/StreamFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/StreamFilter.php
@@ -123,6 +123,9 @@ abstract class StreamFilter extends Templatable
             foreach ($filtered->get_released() as $element) {
                 $tracer->release_element($this, $element);
             }
+            if (count($elements) === $filtered->get_released_count()) {
+                $tracer->release_all_elements($this, $filtered->get_released_count());
+            }
         }
         return $filtered;
     }

--- a/lib/Tumblr/StreamBuilder/StreamTracers/StreamTracer.php
+++ b/lib/Tumblr/StreamBuilder/StreamTracers/StreamTracer.php
@@ -65,6 +65,7 @@ abstract class StreamTracer
     public const EVENT_RETRY = 'retry';
     public const EVENT_APPLY = 'apply';
     public const EVENT_RELEASE = 'release';
+    public const EVENT_RELEASE_ALL = 'release_all';
     public const EVENT_CACHE_HIT = 'cache_hit';
     public const EVENT_CACHE_MISS = 'cache_miss';
     public const EVENT_EXHAUSTIVE = 'exhaustive';
@@ -453,6 +454,24 @@ abstract class StreamTracer
             static::CATEGORY_FILTER,
             $filter,
             static::EVENT_RELEASE,
+            [],
+            $meta
+        );
+    }
+
+    /**
+     * Called when a filter releases all the elements.
+     * @param StreamFilter $filter The stream filter that released the elements.
+     * @param int $count The amount of elements released.
+     * @return void
+     */
+    public function release_all_elements(StreamFilter $filter, int $count)
+    {
+        $meta = [static::META_COUNT => $count];
+        $this->trace_event(
+            static::CATEGORY_FILTER,
+            $filter,
+            static::EVENT_RELEASE_ALL,
             [],
             $meta
         );

--- a/tests/unit/Tumblr/StreamBuilder/StreamFilters/StreamFilterTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamFilters/StreamFilterTest.php
@@ -57,8 +57,10 @@ class StreamFilterTest extends \PHPUnit\Framework\TestCase
 
         // Example output:
         // [2024-01-16T09:28:33-05:00]: op=filter sender=ello[Mock_StreamFilter_e7231ac5] status=begin other={"count":2}
-        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=end start_time=1705416992.4759 duration=2.0980834960938E-5 other={"count":1}
-        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=release other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(123)","filter_code":"Mock_StreamFilter_3aaefcd3"}
+        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=end
+        //      start_time=1705416992.4759 duration=2.0980834960938E-5 other={"count":1}
+        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=release
+        //      other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(123)","filter_code":"Mock_StreamFilter_3aaefcd3"}
         $this->assertMatchesRegularExpression(
             "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=begin.other=\{\"count\":2\}/",
             $tracer->get_output()[0]
@@ -99,9 +101,12 @@ class StreamFilterTest extends \PHPUnit\Framework\TestCase
 
         // Example output:
         // [2024-01-16T09:28:33-05:00]: op=filter sender=ello[Mock_StreamFilter_e7231ac5] status=begin other={"count":2}
-        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=end start_time=1705416992.4759 duration=2.0980834960938E-5 other={"count":2}
-        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=release other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(123)","filter_code":"Mock_StreamFilter_3aaefcd3"}
-        // [2024-01-16T10:06:02-05:00]: op=filter sender=ello[Mock_StreamFilter_bd6d5ece] status=release other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(234)","filter_code":"Mock_StreamFilter_bd6d5ece"}
+        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=end
+        //      start_time=1705416992.4759 duration=2.0980834960938E-5 other={"count":2}
+        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=release
+        //      other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(123)","filter_code":"Mock_StreamFilter_3aaefcd3"}
+        // [2024-01-16T10:06:02-05:00]: op=filter sender=ello[Mock_StreamFilter_bd6d5ece] status=release
+        //      other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(234)","filter_code":"Mock_StreamFilter_bd6d5ece"}
         // [2024-01-16T10:06:02-05:00]: op=filter sender=ello[Mock_StreamFilter_bd6d5ece] status=release_all other={"count":2}
         $this->assertMatchesRegularExpression(
             "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=begin.other=\{\"count\":2\}/",

--- a/tests/unit/Tumblr/StreamBuilder/StreamFilters/StreamFilterTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamFilters/StreamFilterTest.php
@@ -25,6 +25,7 @@ use Test\Tumblr\StreamBuilder\StreamCursors\MockMaxCursor;
 use Test\Tumblr\StreamBuilder\StreamElements\MockMaxStreamElement;
 use Tumblr\StreamBuilder\StreamFilterResult;
 use Tumblr\StreamBuilder\StreamFilters\StreamFilter;
+use Tumblr\StreamBuilder\StreamTracers\DebugStreamTracer;
 use Tumblr\StreamBuilder\StreamTracers\StreamTracer;
 
 /**
@@ -43,15 +44,87 @@ class StreamFilterTest extends \PHPUnit\Framework\TestCase
             ->setMethods(['filter_inner'])
             ->getMockForAbstractClass();
         $el = new MockMaxStreamElement(123, 'awesome_provider', new MockMaxCursor(456));
+        $el2 = new MockMaxStreamElement(234, 'awesome_provider', new MockMaxCursor(789));
         $released_el = $el;
         $filter->expects($this->once())
             ->method('filter_inner')
             ->willReturn(new StreamFilterResult([], [$released_el]));
 
-        $tracer = $this->getMockBuilder(StreamTracer::class)->getMockForAbstractClass();
+        $tracer = new DebugStreamTracer();
 
-        $filter->filter([$el], null, $tracer);
+        $filter->filter([$el, $el2], null, $tracer);
+        $this->assertCount(3, $tracer->get_output());
+
+        // Example output:
+        // [2024-01-16T09:28:33-05:00]: op=filter sender=ello[Mock_StreamFilter_e7231ac5] status=begin other={"count":2}
+        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=end start_time=1705416992.4759 duration=2.0980834960938E-5 other={"count":1}
+        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=release other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(123)","filter_code":"Mock_StreamFilter_3aaefcd3"}
+        $this->assertMatchesRegularExpression(
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=begin.other=\{\"count\":2\}/",
+            $tracer->get_output()[0]
+        );
+        $this->assertMatchesRegularExpression(
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=end.start_time=.*duration=.*other=\{\"count\":1\}/",
+            $tracer->get_output()[1]
+        );
+        $this->assertMatchesRegularExpression(
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=release.*other=\{\"target\":\"MockMaxStreamElement\",\"meta_detail\":\"TEST_MockMaxElement\(123\)\",\"filter_code\":\"Mock_StreamFilter_.*\".*\}/",
+            $tracer->get_output()[2]
+        );
     }
+
+
+    /**
+     * Test that the filter method calls filter_all when all elements are filtered
+     */
+    public function test_filter_all()
+    {
+        /** @var StreamFilter|\PHPUnit\Framework\MockObject\MockObject $filter */
+        $filter = $this->getMockBuilder(StreamFilter::class)
+            ->setConstructorArgs(['ello'])
+            ->setMethods(['filter_inner'])
+            ->getMockForAbstractClass();
+        $el = new MockMaxStreamElement(123, 'awesome_provider', new MockMaxCursor(456));
+        $el2 = new MockMaxStreamElement(234, 'awesome_provider', new MockMaxCursor(789));
+        $released_el = $el;
+        $released_el2 = $el2;
+        $filter->expects($this->once())
+            ->method('filter_inner')
+            ->willReturn(new StreamFilterResult([], [$el, $el2]));
+
+        $tracer = new DebugStreamTracer();
+
+        $filter->filter([$el, $el2], null, $tracer);
+        $this->assertCount(5, $tracer->get_output());
+
+        // Example output:
+        // [2024-01-16T09:28:33-05:00]: op=filter sender=ello[Mock_StreamFilter_e7231ac5] status=begin other={"count":2}
+        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=end start_time=1705416992.4759 duration=2.0980834960938E-5 other={"count":2}
+        // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=release other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(123)","filter_code":"Mock_StreamFilter_3aaefcd3"}
+        // [2024-01-16T10:06:02-05:00]: op=filter sender=ello[Mock_StreamFilter_bd6d5ece] status=release other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(234)","filter_code":"Mock_StreamFilter_bd6d5ece"}
+        // [2024-01-16T10:06:02-05:00]: op=filter sender=ello[Mock_StreamFilter_bd6d5ece] status=release_all other={"count":2}
+        $this->assertMatchesRegularExpression(
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=begin.other=\{\"count\":2\}/",
+            $tracer->get_output()[0]
+        );
+        $this->assertMatchesRegularExpression(
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=end.start_time=.*duration=.*other=\{\"count\":2\}/",
+            $tracer->get_output()[1]
+        );
+        $this->assertMatchesRegularExpression(
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=release.*other=\{\"target\":\"MockMaxStreamElement\",\"meta_detail\":\"TEST_MockMaxElement\(123\)\",\"filter_code\":\"Mock_StreamFilter_.*\".*\}/",
+            $tracer->get_output()[2]
+        );
+        $this->assertMatchesRegularExpression(
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=release.*other=\{\"target\":\"MockMaxStreamElement\",\"meta_detail\":\"TEST_MockMaxElement\(234\)\",\"filter_code\":\"Mock_StreamFilter_.*\".*\}/",
+            $tracer->get_output()[3]
+        );
+        $this->assertMatchesRegularExpression(
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=release_all.other=\{\"count\":2\}/",
+            $tracer->get_output()[4]
+        );
+    }
+
 
     /**
      * Test when filter throw exception


### PR DESCRIPTION


### What and why? 🤔

We want to track when filters are the cause of stream exhaustion. This can happen when a filter releases all elements, the remaining elements is empty and if we don't set retry and overfetch properly, it can cause stream exhaustion. 

On this PR we implement release_all_elements on StreamTracer. We call this method on the `filter` step of `StreamFilter`  so that we can track when a filter releases all the elements on the filter step. 


### Testing Steps ✍️

Provide adequate testing steps (including examples if necessary).
Don't assume someone knows how to test your changes; be thorough.

- [ ] Bullet point checklists
- [ ] Are useful for some tests

### You're it! 👑

@Automattic/stream-builders