### PR TITLE
add release ratio to meta field on the end_filter tracer method

### DIFF
--- a/lib/Tumblr/StreamBuilder/StreamFilters/StreamFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/StreamFilter.php
@@ -77,10 +77,10 @@ abstract class StreamFilter extends Templatable
      * Filter stream elements, this method will trace filter process, and proxy the concrete filter implementation
      * to the filter_inner method.
      * @param StreamElement[] $elements The candidate StreamElement instances to filter.
-     * @param StreamFilterState $state The filter state passed from previous filter operations.
+     * @param StreamFilterState|null $state The filter state passed from previous filter operations.
      * @param StreamTracer|null $tracer The tracer passed in to track filter behaviors.
-     * @throws \Exception Rethrown exceptions from filter_inner call.
      * @return StreamFilterResult
+     * @throws \Exception Rethrown exceptions from filter_inner call.
      */
     final public function filter(
         array $elements,
@@ -118,12 +118,13 @@ abstract class StreamFilter extends Templatable
             $tracer->end_filter(
                 $this,
                 $filtered->get_released_count(),
-                [$t0, microtime(true) - $t0]
+                [$t0, microtime(true) - $t0],
+                $size
             );
             foreach ($filtered->get_released() as $element) {
                 $tracer->release_element($this, $element);
             }
-            if (count($elements) === $filtered->get_released_count()) {
+            if ($size > 0 && $size === $filtered->get_released_count()) {
                 $tracer->release_all_elements($this, $filtered->get_released_count());
             }
         }
@@ -133,7 +134,7 @@ abstract class StreamFilter extends Templatable
     /**
      * The filter concrete logic implementation.
      * @param StreamElement[] $elements The candidate StreamElement instances to filter.
-     * @param StreamFilterState $state The filter state passed from previous filter operations.
+     * @param StreamFilterState|null $state The filter state passed from previous filter operations.
      * @param StreamTracer|null $tracer The tracer passed in to track filter behaviors.
      * @return StreamFilterResult
      */

--- a/lib/Tumblr/StreamBuilder/StreamFilters/StreamFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/StreamFilter.php
@@ -138,7 +138,7 @@ abstract class StreamFilter extends Templatable
      * @param StreamTracer|null $tracer The tracer passed in to track filter behaviors.
      * @return StreamFilterResult
      */
-    abstract protected function filter_inner(array $elements, StreamFilterState $state = null, StreamTracer $tracer = null): StreamFilterResult;
+    abstract protected function filter_inner(array $elements, ?StreamFilterState $state = null, ?StreamTracer $tracer = null): StreamFilterResult;
 
     /**
      * Whether this filter is enabled. Default to true.

--- a/lib/Tumblr/StreamBuilder/StreamFilters/StreamFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/StreamFilter.php
@@ -87,7 +87,7 @@ abstract class StreamFilter extends Templatable
         ?StreamFilterState $state = null,
         ?StreamTracer $tracer = null
     ): StreamFilterResult {
-        if (!$this->can_filter()) {
+        if (!$this->can_filter() || $elements === []) {
             $tracer && $tracer->filter_skip($this);
             return new StreamFilterResult($elements, []);
         }

--- a/lib/Tumblr/StreamBuilder/StreamTracers/StreamTracer.php
+++ b/lib/Tumblr/StreamBuilder/StreamTracers/StreamTracer.php
@@ -387,21 +387,30 @@ abstract class StreamTracer
      * @param StreamFilter $filter The stream filter is applied.
      * @param int $released_count The number of items being filtered.
      * @param array $timing Zero indexed tuple of the start time and duration of the operation (in that order)
+     * @param int $total_count The number of elements that went through the filter step, out of which $release_count were filtered.
      * @return void
      */
     final public function end_filter(
         StreamFilter $filter,
         int $released_count,
-        array $timing
+        array $timing,
+        int $total_count
     ): void {
+        $meta = [static::META_COUNT => $released_count];
+
+        if ($total_count > 0) {
+            $ratio = $released_count / $total_count;
+            $meta['released_ratio'] = $ratio;
+        } else {
+            $meta['released_ratio'] = 0;
+        }
+
         $this->trace_event(
             static::CATEGORY_FILTER,
             $filter,
             static::EVENT_END,
             $timing,
-            [
-                static::META_COUNT => $released_count,
-            ]
+            $meta
         );
     }
 

--- a/lib/Tumblr/StreamBuilder/StreamTracers/StreamTracer.php
+++ b/lib/Tumblr/StreamBuilder/StreamTracers/StreamTracer.php
@@ -400,7 +400,7 @@ abstract class StreamTracer
 
         if ($total_count > 0) {
             $ratio = $released_count / $total_count;
-            $meta['released_ratio'] = $ratio;
+            $meta['released_ratio'] = round($ratio, 3);
         } else {
             $meta['released_ratio'] = 0;
         }

--- a/tests/unit/Tumblr/StreamBuilder/StreamFilters/StreamFilterTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamFilters/StreamFilterTest.php
@@ -45,27 +45,29 @@ class StreamFilterTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
         $el = new MockMaxStreamElement(123, 'awesome_provider', new MockMaxCursor(456));
         $el2 = new MockMaxStreamElement(234, 'awesome_provider', new MockMaxCursor(789));
+        $el3 = new MockMaxStreamElement(345, 'awesome_provider', new MockMaxCursor(987));
         $filter->expects($this->once())
             ->method('filter_inner')
             ->willReturn(new StreamFilterResult([], [$el]));
 
         $tracer = new DebugStreamTracer();
 
-        $filter->filter([$el, $el2], null, $tracer);
+        $filter->filter([$el, $el2, $el3], null, $tracer);
         $this->assertCount(3, $tracer->get_output());
 
         // Example output:
         // [2024-01-16T09:28:33-05:00]: op=filter sender=ello[Mock_StreamFilter_e7231ac5] status=begin other={"count":2}
         // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=end
         //      start_time=1705427127.9359 duration=7.1525573730469E-6 other={"count":1,"released_ratio":1}
+        //      start_time=1705427127.9359 duration=7.1525573730469E-6 other={"count":2,"released_ratio":0.333}
         // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=release
         //      other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(123)","filter_code":"Mock_StreamFilter_3aaefcd3"}
         $this->assertMatchesRegularExpression(
-            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=begin.other=\{\"count\":2\}/",
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=begin.other=\{\"count\":3\}/",
             $tracer->get_output()[0]
         );
         $this->assertMatchesRegularExpression(
-            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=end.start_time=.*duration=.*other=\{\"count\":1,\"released_ratio\":0.5\}/",
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=end.start_time=.*duration=.*other=\{\"count\":1,\"released_ratio\":0.333\}/",
             $tracer->get_output()[1]
         );
         $this->assertMatchesRegularExpression(

--- a/tests/unit/Tumblr/StreamBuilder/StreamFilters/StreamFilterTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamFilters/StreamFilterTest.php
@@ -57,7 +57,7 @@ class StreamFilterTest extends \PHPUnit\Framework\TestCase
         // Example output:
         // [2024-01-16T09:28:33-05:00]: op=filter sender=ello[Mock_StreamFilter_e7231ac5] status=begin other={"count":2}
         // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=end
-        //      start_time=1705427127.9359 duration=7.1525573730469E-6 other={"count":2,"released_ratio":1}
+        //      start_time=1705427127.9359 duration=7.1525573730469E-6 other={"count":1,"released_ratio":1}
         // [2024-01-16T09:56:32-05:00]: op=filter sender=ello[Mock_StreamFilter_3aaefcd3] status=release
         //      other={"target":"MockMaxStreamElement","meta_detail":"TEST_MockMaxElement(123)","filter_code":"Mock_StreamFilter_3aaefcd3"}
         $this->assertMatchesRegularExpression(

--- a/tests/unit/Tumblr/StreamBuilder/StreamFilters/StreamFilterTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamFilters/StreamFilterTest.php
@@ -138,26 +138,20 @@ class StreamFilterTest extends \PHPUnit\Framework\TestCase
             ->setConstructorArgs(['ello'])
             ->setMethods(['filter_inner'])
             ->getMockForAbstractClass();
-        $filter->expects($this->once())
+        $filter->expects($this->never())
             ->method('filter_inner')
             ->willReturn(new StreamFilterResult([], []));
 
         $tracer = new DebugStreamTracer();
 
         $filter->filter([], null, $tracer);
-        $this->assertCount(2, $tracer->get_output());
+        $this->assertCount(1, $tracer->get_output());
 
         // Example output:
-        // [2024-01-16T09:28:33-05:00]: op=filter sender=ello[Mock_StreamFilter_e7231ac5] status=begin other={"count":0}
-        // [2024-01-16T12:45:27-05:00]: op=filter sender=ello[Mock_StreamFilter_29ee789b] status=end
-        //      start_time=1705427127.9359 duration=7.1525573730469E-6 other={"count":0,"released_ratio":0}
+        // [2024-01-16T09:28:33-05:00]: op=filter sender=ello[Mock_StreamFilter_e7231ac5] status=skip
         $this->assertMatchesRegularExpression(
-            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=begin.other=\{\"count\":0\}/",
+            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=skip/",
             $tracer->get_output()[0]
-        );
-        $this->assertMatchesRegularExpression(
-            "/op=filter.sender=ello\[Mock_StreamFilter_[a-z0-9A-Z]*\].status=end.start_time=.*duration=.*other=\{\"count\":0,\"released_ratio\":0\}/",
-            $tracer->get_output()[1]
         );
     }
 
@@ -178,7 +172,8 @@ class StreamFilterTest extends \PHPUnit\Framework\TestCase
             ->willThrowException(new \Exception('whoops'));
 
         $tracer = $this->getMockBuilder(StreamTracer::class)->getMockForAbstractClass();
+        $el = new MockMaxStreamElement(123, 'awesome_provider', new MockMaxCursor(456));
 
-        $filter->filter([], null, $tracer);
+        $filter->filter([$el], null, $tracer);
     }
 }


### PR DESCRIPTION


### What and why? 🤔

The `end_filter` event will now log `released_ratio` as part of the meta fields. The released rate is computed as : `number of released elements /  total number of elements`. 

If the filter step is called with an empty array, the release count and release rate will be 0.  And "release_all" will not be logged as event.

### Testing Steps ✍️

Code review. Unit tests should all pass.

### You're it! 👑

@Automattic/stream-builders
