### PR TITLE
Fix PHP 8 deprecated notices

### DIFF
--- a/lib/Tumblr/StreamBuilder/Codec/CacheCodec.php
+++ b/lib/Tumblr/StreamBuilder/Codec/CacheCodec.php
@@ -109,8 +109,8 @@ final class CacheCodec extends Codec
             throw new MissingCacheException($this->cache_type, $encoded);
         }
 
-        // there used to be a bug on memcache client, add an extra utf8_encode call here to make sure.
-        $cached = utf8_encode($cached);
+        // there used to be a bug on memcache client, add an extra encoding call here to make sure.
+        $cached = mb_convert_encoding($cached, 'UTF-8', 'ISO-8859-1');
 
         switch ($this->serialization_type) {
             case self::SERIALIZATION_TYPE_JSON:

--- a/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursorSerializer.php
+++ b/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursorSerializer.php
@@ -78,7 +78,7 @@ final class StreamCursorSerializer
         ?string $user_id,
         ?string $context = null
     ): ?StreamCursor {
-        if (empty(trim($cursor_string))) {
+        if (empty(trim($cursor_string ?? ''))) {
             return null;
         }
         $cache_provider = StreamBuilder::getDependencyBag()->getCacheProvider();

--- a/lib/Tumblr/StreamBuilder/Streams/CachedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/CachedStream.php
@@ -148,7 +148,7 @@ abstract class CachedStream extends WrapStream
         } else {
             $ttl = $this->cache_ttl;
         }
-        $this->cache_provider->set($this->cache_object_type, $cache_key, $cache_value, $ttl);
+        $this->cache_provider->set($this->cache_object_type, $cache_key, $cache_value, (int) $ttl);
 
         // Step 4: Slice the result and serve the requested based on cursor.
         // we will still use the same cursor's offset to slice the newly fetched results.

--- a/lib/Tumblr/StreamBuilder/TemplateProvider.php
+++ b/lib/Tumblr/StreamBuilder/TemplateProvider.php
@@ -174,7 +174,7 @@ abstract class TemplateProvider
             !(static::template_exists($context, $test_template_name))
         ) {
             // planout variant is not a valid template, fallback to default template.
-            StreamBuilder::getDependencyBag()->getLog()->rateTick('streambuilder_errors', "${context}_bad_test_template_name");
+            StreamBuilder::getDependencyBag()->getLog()->rateTick('streambuilder_errors', "{$context}_bad_test_template_name");
             return $default_template_name;
         }
         return $test_template_name;

--- a/tests/unit/Tumblr/StreamBuilder/StreamRankers/CappedPostRankerTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamRankers/CappedPostRankerTest.php
@@ -45,6 +45,26 @@ class CappedPostRankerTest extends \PHPUnit\Framework\TestCase
     private MockedUser $mock_user;
 
     /**
+     * @var array Array of valid stream elements.
+     */
+    private array $stream_elements;
+
+    /**
+     * @var array Array of invalid stream elements.
+     */
+    private array $invalid_stream_elements;
+
+    /**
+     * @var CappedPostRanker Enabled ranker instance.
+     */
+    private CappedPostRanker $enabled_ranker_instance;
+
+    /**
+     * @var CappedPostRanker Disabled ranker instance.
+     */
+    private CappedPostRanker $disabled_ranker_instance;
+
+    /**
      * Set up the testcase
      */
     protected function setUp(): void


### PR DESCRIPTION
### What and why? 🤔

This PR fixes some deprecation notices I _noticed_ when running tests on PHP 8.2.

### Testing Steps ✍️

To verify notices are not generated anymore, run tests on PHP 8.2:

```
vendor/bin/phpunit
```

Tests should also pass on PHP 7.4, as the changes made here should be backwards compatible.

### You're it! 👑

@Automattic/stream-builders
