### PR TITLE
add component name for TemplateProvider::get_template error message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,8 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "infection/extension-installer": true,
-            "ergebnis/composer-normalize": true
+            "ergebnis/composer-normalize": true,
+            "infection/extension-installer": true
         }
     }
 }

--- a/lib/Tumblr/StreamBuilder/TemplateProvider.php
+++ b/lib/Tumblr/StreamBuilder/TemplateProvider.php
@@ -36,8 +36,9 @@ abstract class TemplateProvider
      * @param string $context The context under which to look for a template.
      * @param string $name The name of the template.
      * @param string|null $component The requested component.
-     * @throws TemplateNotFoundException If the requested template could not be found or opened.
-     * Also can throw \JsonException If the file exists, but contains invalid JSON.
+     * @throws TemplateNotFoundException If the requested template could not be found or opened,
+     * also can throw \JsonException If the file exists, but contains invalid JSON,
+     * or if the requested component is not present in the template.
      * @return array The requested template as a deserialized array.
      */
     public static function get_template(string $context, string $name, ?string $component = null): array
@@ -45,9 +46,12 @@ abstract class TemplateProvider
         $template = YamlTemplateProvider::getInstance()->getTemplate($context, $name, $component) ??
             ConfigTemplateProvider::getInstance()->getTemplate($context, $name, $component);
         if (empty($template)) {
-            throw new TemplateNotFoundException(
-                sprintf('Cannot read template for %s:%s', $context, $name)
-            );
+            if ($component !== null && $component !== '') {
+                $message = sprintf('Cannot read template for %s:%s component:%s', $context, $name, $component);
+            } else {
+                $message = sprintf('Cannot read template for %s:%s', $context, $name);
+            }
+            throw new TemplateNotFoundException($message);
         }
         return $template;
     }

--- a/tests/unit/Tumblr/StreamBuilder/TemplateProviderTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/TemplateProviderTest.php
@@ -141,4 +141,38 @@ class TemplateProviderTest extends \PHPUnit\Framework\TestCase
         }
         $this->assertTrue(TemplateProvider::template_exists('dashboard', $template));
     }
+
+    /**
+     * Test get_template
+     * @return void
+     */
+    public function testGetTemplate(): void
+    {
+        $template = TemplateProvider::get_template('examples', 'empty');
+        $expected = [
+            '_type' => 'Tumblr\StreamBuilder\Streams\NullStream',
+            '_component' => 'examples',
+        ];
+        $this->assertSame($expected, $template);
+    }
+
+    /**
+     * Test get_template
+     * @return void
+     */
+    public function testGetTemplateWithMissingTemplate(): void
+    {
+        $this->expectExceptionMessage('Cannot read template for examples:posts_feed');
+        TemplateProvider::get_template('examples', 'posts_feed');
+    }
+
+    /**
+     * Test get_template
+     * @return void
+     */
+    public function testGetTemplateWithMissingComponent(): void
+    {
+        $this->expectExceptionMessage('Cannot read template for examples:empty component:posts');
+        TemplateProvider::get_template('examples', 'empty', 'posts');
+    }
 }


### PR DESCRIPTION

### What and why? 🤔

On tumblr, we sometimes see a template not found error, for templates that do exist. When debugging the issue we found that the thing missing was the requested component within the template.

This PR adds the requested component name to the error message.

### Testing Steps ✍️

Code review and unit tests should be enough

### You're it! 👑

@Automattic/stream-builders
