### PR TITLE
Update release_ping.yml

### DIFF
--- a/.github/workflows/release_ping.yml
+++ b/.github/workflows/release_ping.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       release_url: ${{ github.event.release.html_url && github.event.release.html_url || 'http://automattic.com' }}
-      release_name: ${{ github.event.release.name && github.event.release.name || github.inputs.release_name }}
+      release_name: ${{ github.event.release.name && github.event.release.name || inputs.release_name }}
       SLACK_WEBHOOK_URL: ${{ secrets.RELEASE_SLACK_WEBHOOK }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:


### PR DESCRIPTION
### What and why? 🤔

Fix the release_name when testing by manually triggering the workflow. The release name was appearing as empty string when running the workflow manually.

### Testing Steps ✍️

Visual inspection.

### You're it! 👑

Tag a random reviewer by adding `@Automattic/stream-builders` to the reviewers section, but mention them here for visibility as well.

@lucila 