### PR TITLE
Test on PHP 8.4

### DIFF
--- a/.github/workflows/ca.yml
+++ b/.github/workflows/ca.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         php-version:
+          - "7.4"
           - "8.1"
 
     steps:

--- a/.github/workflows/ca.yml
+++ b/.github/workflows/ca.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.1"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         php-version:
+          - "7.4"
           - "8.1"
 
     steps:

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.1"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
+          - "8.1"
 
     defaults:
       run:

--- a/.github/workflows/mt.yml
+++ b/.github/workflows/mt.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.2"
+          - "8.4"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -22,6 +22,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
 
     steps:
       - uses: actions/checkout@v3

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -66,6 +66,7 @@ $config
         'blank_line_after_opening_tag' => false,
         'linebreak_after_opening_tag' => false,
         'blank_line_between_import_groups' => false,
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/example/src/Automattic/MyAwesomeReader/StreamBuilder/Trending/Streams/TrendingTopicStream.php
+++ b/example/src/Automattic/MyAwesomeReader/StreamBuilder/Trending/Streams/TrendingTopicStream.php
@@ -48,8 +48,8 @@ class TrendingTopicStream extends Stream
     /** @inheritDoc */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         if (!$cursor instanceof TrendingTopicStreamCursor) {

--- a/extras/phpcs/TumblrApp/ruleset.xml
+++ b/extras/phpcs/TumblrApp/ruleset.xml
@@ -202,6 +202,7 @@
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.PHP.ShortList" />
+    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
             <property name="declareOnFirstLine" value="true"/>

--- a/lib/Tumblr/StreamBuilder/Codec/Codec.php
+++ b/lib/Tumblr/StreamBuilder/Codec/Codec.php
@@ -75,7 +75,7 @@ abstract class Codec
      * @param CacheProvider|null $cache_provider The cache provider used to deserialize a template.
      * @see @StreamContext, there are stuff from stream are cached during the to_template process.
      */
-    public function __construct(CacheProvider $cache_provider = null)
+    public function __construct(?CacheProvider $cache_provider = null)
     {
         $this->cache_provider = $cache_provider;
     }

--- a/lib/Tumblr/StreamBuilder/Exceptions/InvalidStreamArrayException.php
+++ b/lib/Tumblr/StreamBuilder/Exceptions/InvalidStreamArrayException.php
@@ -30,7 +30,7 @@ class InvalidStreamArrayException extends \InvalidArgumentException
     /**
      * @param array|null $stream_array The stream_array which is sent to the deserializer
      */
-    public function __construct(array $stream_array = null)
+    public function __construct(?array $stream_array = null)
     {
         parent::__construct(sprintf(
             'Invalid stream array: %s',

--- a/lib/Tumblr/StreamBuilder/Exceptions/TemplateNotFoundException.php
+++ b/lib/Tumblr/StreamBuilder/Exceptions/TemplateNotFoundException.php
@@ -32,7 +32,7 @@ class TemplateNotFoundException extends \InvalidArgumentException
      * @param int $code The exception code.
      * @param \Throwable $previous The previous exception.
      */
-    public function __construct($message = "Template not found", $code = 404, \Throwable $previous = null)
+    public function __construct($message = "Template not found", $code = 404, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/lib/Tumblr/StreamBuilder/FencepostRanking/FencepostCursor.php
+++ b/lib/Tumblr/StreamBuilder/FencepostRanking/FencepostCursor.php
@@ -79,8 +79,8 @@ final class FencepostCursor extends StreamCursor
         int $fencepost_timestamp_ms,
         int $region,
         int $head_offset,
-        StreamCursor $tail_cursor = null,
-        StreamCursor $inject_cursor = null
+        ?StreamCursor $tail_cursor = null,
+        ?StreamCursor $inject_cursor = null
     ) {
         if ($region !== self::REGION_INJECT && is_null($tail_cursor)) {
             throw new \InvalidArgumentException('Head or Tail region must contains tail_cursor');

--- a/lib/Tumblr/StreamBuilder/FencepostRanking/FencepostRankedStream.php
+++ b/lib/Tumblr/StreamBuilder/FencepostRanking/FencepostRankedStream.php
@@ -166,8 +166,8 @@ abstract class FencepostRankedStream extends Stream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         if (!(is_null($cursor) || ($cursor instanceof FencepostCursor))) {
@@ -195,7 +195,7 @@ abstract class FencepostRankedStream extends Stream
      * @param EnumerationOptions|null $option The option on enumeration
      * @return array [Fencepost|null, FencepostRankedStreamCursor|null]
      */
-    private function setup_enumeration(FencepostCursor $in_cursor = null, StreamTracer $tracer = null, ?EnumerationOptions $option = null)
+    private function setup_enumeration(?FencepostCursor $in_cursor = null, ?StreamTracer $tracer = null, ?EnumerationOptions $option = null)
     {
         if (!is_null($in_cursor)) {
             // you already have a cursor, try to turn it into a fencepost:
@@ -287,7 +287,7 @@ abstract class FencepostRankedStream extends Stream
     private function setup_enumeration_from_new_fencepost(
         ?StreamTracer $tracer,
         int $now_ms,
-        int $latest_ms = null,
+        ?int $latest_ms = null,
         ?EnumerationOptions $option = null
     ): array {
         $fencepost = $this->commit_new_fencepost($now_ms, $latest_ms, $tracer, $option);
@@ -558,7 +558,7 @@ abstract class FencepostRankedStream extends Stream
     protected function enumerate_final(
         int $count,
         FencepostCursor $cursor,
-        StreamTracer $tracer = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         StreamBuilder::getDependencyBag()->getLog()
@@ -580,7 +580,7 @@ abstract class FencepostRankedStream extends Stream
         int $count,
         ?StreamCursor $cursor,
         ?int $fencepost_timestamp_ms,
-        StreamTracer $tracer = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         $inner_result = $this->inner->enumerate($count, $cursor, $tracer, $option);
@@ -608,8 +608,8 @@ abstract class FencepostRankedStream extends Stream
      */
     protected function commit_new_fencepost(
         int $current_ms,
-        int $previous_fencepost_ms = null,
-        StreamTracer $tracer = null,
+        ?int $previous_fencepost_ms = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ) {
         // we are building a new fencepost between $current_ms and $previous_fencepost_ms.
@@ -659,8 +659,8 @@ abstract class FencepostRankedStream extends Stream
         int $before_ms_inclusive,
         ?int $after_ms_exclusive,
         int $count,
-        StreamCursor $inner_cursor = null,
-        StreamTracer $tracer = null
+        ?StreamCursor $inner_cursor = null,
+        ?StreamTracer $tracer = null
     ): StreamResult {
         $option = new EnumerationOptions($before_ms_inclusive, $after_ms_exclusive);
         $result = $this->inner->enumerate($count, $inner_cursor, $tracer, $option);
@@ -701,7 +701,7 @@ abstract class FencepostRankedStream extends Stream
     public function log_commit_new_fence_stats(
         StreamResult $unranked_candidates,
         int $current_ms,
-        int $previous_fencepost_ms = null
+        ?int $previous_fencepost_ms = null
     ): void {
         $ps_gap_in_seconds = ($current_ms - ($previous_fencepost_ms ?? 0)) / 1000;
         // Track when last_ts is missing, putting 1 second as a placeholder

--- a/lib/Tumblr/StreamBuilder/InjectionAllocatorResult.php
+++ b/lib/Tumblr/StreamBuilder/InjectionAllocatorResult.php
@@ -39,7 +39,7 @@ final class InjectionAllocatorResult
      * @param array|null $state The injector state to coordinate between different pages.
      * @throws TypeMismatchException If position is not an int.
      */
-    public function __construct(array $out, array $state = null)
+    public function __construct(array $out, ?array $state = null)
     {
         foreach ($out as $position) {
             if (!is_int($position)) {

--- a/lib/Tumblr/StreamBuilder/InjectionAllocators/ExpectedValueInjectionAllocator.php
+++ b/lib/Tumblr/StreamBuilder/InjectionAllocators/ExpectedValueInjectionAllocator.php
@@ -72,7 +72,7 @@ final class ExpectedValueInjectionAllocator extends InjectionAllocator
     /**
      * @inheritDoc
      */
-    public function allocate(int $page_size, array $state = null): InjectionAllocatorResult
+    public function allocate(int $page_size, ?array $state = null): InjectionAllocatorResult
     {
         $expected_value = $page_size * $this->slot_injection_probability;
         $count = floor($expected_value);

--- a/lib/Tumblr/StreamBuilder/InjectionAllocators/GlobalFixedInjectionAllocator.php
+++ b/lib/Tumblr/StreamBuilder/InjectionAllocators/GlobalFixedInjectionAllocator.php
@@ -32,7 +32,7 @@ class GlobalFixedInjectionAllocator extends FixedInjectionAllocator
     /**
      * @inheritDoc
      */
-    public function allocate(int $page_size, array $state = null): InjectionAllocatorResult
+    public function allocate(int $page_size, ?array $state = null): InjectionAllocatorResult
     {
         $pos_base = $state['pos_base'] ?? 0;
         $out = [];

--- a/lib/Tumblr/StreamBuilder/InjectionAllocators/InjectionAllocator.php
+++ b/lib/Tumblr/StreamBuilder/InjectionAllocators/InjectionAllocator.php
@@ -36,5 +36,5 @@ abstract class InjectionAllocator extends Templatable
      * @param array|null $state The state of the injector.
      * @return InjectionAllocatorResult .
      */
-    abstract public function allocate(int $page_size, array $state = null): InjectionAllocatorResult;
+    abstract public function allocate(int $page_size, ?array $state = null): InjectionAllocatorResult;
 }

--- a/lib/Tumblr/StreamBuilder/InjectionAllocators/LocalFixedInjectionAllocator.php
+++ b/lib/Tumblr/StreamBuilder/InjectionAllocators/LocalFixedInjectionAllocator.php
@@ -31,7 +31,7 @@ class LocalFixedInjectionAllocator extends FixedInjectionAllocator
     /**
      * @inheritDoc
      */
-    public function allocate(int $page_size, array $state = null): InjectionAllocatorResult
+    public function allocate(int $page_size, ?array $state = null): InjectionAllocatorResult
     {
         $out = [];
         foreach ($this->positions as $p) {

--- a/lib/Tumblr/StreamBuilder/InjectionAllocators/ProbabilisticInjectionAllocator.php
+++ b/lib/Tumblr/StreamBuilder/InjectionAllocators/ProbabilisticInjectionAllocator.php
@@ -61,7 +61,7 @@ final class ProbabilisticInjectionAllocator extends InjectionAllocator
     /**
      * @inheritDoc
      */
-    public function allocate(int $page_size, array $state = null): InjectionAllocatorResult
+    public function allocate(int $page_size, ?array $state = null): InjectionAllocatorResult
     {
         $out = [];
         $mt_randmax = mt_getrandmax();

--- a/lib/Tumblr/StreamBuilder/InjectionAllocators/UniformInjectionAllocator.php
+++ b/lib/Tumblr/StreamBuilder/InjectionAllocators/UniformInjectionAllocator.php
@@ -71,7 +71,7 @@ final class UniformInjectionAllocator extends InjectionAllocator
     /**
      * @inheritDoc
      */
-    public function allocate(int $page_size, array $state = null): InjectionAllocatorResult
+    public function allocate(int $page_size, ?array $state = null): InjectionAllocatorResult
     {
         $out = [];
         // If there's no next_offset is set, we use remainder, most likely in the first page.

--- a/lib/Tumblr/StreamBuilder/InjectionPlan.php
+++ b/lib/Tumblr/StreamBuilder/InjectionPlan.php
@@ -47,7 +47,7 @@ class InjectionPlan
      * @param array|null $injector_state An array representing the state of the injector, if any, after injection.
      * @throws TypeMismatchException If some value in the provided array is not a StreamInjection.
      */
-    public function __construct(array $index_to_injection, array $injector_state = null)
+    public function __construct(array $index_to_injection, ?array $injector_state = null)
     {
         foreach ($index_to_injection as $j) {
             if (!($j instanceof StreamInjection)) {

--- a/lib/Tumblr/StreamBuilder/SignalFetchers/CompositeSignalFetcher.php
+++ b/lib/Tumblr/StreamBuilder/SignalFetchers/CompositeSignalFetcher.php
@@ -53,7 +53,7 @@ final class CompositeSignalFetcher extends SignalFetcher
     /**
      * @inheritDoc
      */
-    protected function fetch_inner(array $stream_elements, StreamTracer $tracer = null): SignalBundle
+    protected function fetch_inner(array $stream_elements, ?StreamTracer $tracer = null): SignalBundle
     {
         $bundles = [];
         foreach ($this->fetchers as $fetcher) {

--- a/lib/Tumblr/StreamBuilder/SignalFetchers/SignalFetcher.php
+++ b/lib/Tumblr/StreamBuilder/SignalFetchers/SignalFetcher.php
@@ -40,7 +40,7 @@ abstract class SignalFetcher extends Templatable
      * @throws TypeMismatchException If some element is not a StreamElement.
      * @throws \Exception If the signal fetcher fails for some other reason.
      */
-    final public function fetch(array $stream_elements, StreamTracer $tracer = null): SignalBundle
+    final public function fetch(array $stream_elements, ?StreamTracer $tracer = null): SignalBundle
     {
         foreach ($stream_elements as $stream_element) {
             if (!($stream_element instanceof StreamElement)) {
@@ -72,7 +72,7 @@ abstract class SignalFetcher extends Templatable
      * @param StreamTracer|null $tracer Tracer to use for metrics and logging of signal fetching process.
      * @return SignalBundle
      */
-    abstract protected function fetch_inner(array $stream_elements, StreamTracer $tracer = null): SignalBundle;
+    abstract protected function fetch_inner(array $stream_elements, ?StreamTracer $tracer = null): SignalBundle;
 
     /**
      * Get the string representation of the current signal fetcher.

--- a/lib/Tumblr/StreamBuilder/SignalFetchers/TimestampFetcher.php
+++ b/lib/Tumblr/StreamBuilder/SignalFetchers/TimestampFetcher.php
@@ -35,7 +35,7 @@ final class TimestampFetcher extends SignalFetcher
     /**
      * @inheritDoc
      */
-    protected function fetch_inner(array $stream_elements, StreamTracer $tracer = null): SignalBundle
+    protected function fetch_inner(array $stream_elements, ?StreamTracer $tracer = null): SignalBundle
     {
         $builder = new SignalBundleBuilder();
         foreach ($stream_elements as $stream_element) {

--- a/lib/Tumblr/StreamBuilder/StreamCursors/ConcatenatedStreamCursor.php
+++ b/lib/Tumblr/StreamBuilder/StreamCursors/ConcatenatedStreamCursor.php
@@ -39,7 +39,7 @@ class ConcatenatedStreamCursor extends StreamCursor
      * @param StreamCursor $source_cursor The original cursor of element
      * @throws \InvalidArgumentException If source index is not an int.
      */
-    public function __construct(int $source_index, StreamCursor $source_cursor = null)
+    public function __construct(int $source_index, ?StreamCursor $source_cursor = null)
     {
         $this->source_index = $source_index;
         $this->source_cursor = $source_cursor;

--- a/lib/Tumblr/StreamBuilder/StreamCursors/FilteredStreamCursor.php
+++ b/lib/Tumblr/StreamBuilder/StreamCursors/FilteredStreamCursor.php
@@ -42,7 +42,7 @@ final class FilteredStreamCursor extends StreamCursor
      * @param StreamCursor|null $cursor The inner cursor tracking pagination state of the inner stream to be filtered.
      * @param StreamFilterState|null $filter_state The filter state.
      */
-    public function __construct(StreamCursor $cursor = null, StreamFilterState $filter_state = null)
+    public function __construct(?StreamCursor $cursor = null, ?StreamFilterState $filter_state = null)
     {
         $this->cursor = $cursor;
         $this->filter_state = $filter_state;
@@ -83,7 +83,7 @@ final class FilteredStreamCursor extends StreamCursor
      * @param StreamFilterState|null $filter_state The filter state.
      * @return FilteredStreamCursor
      */
-    public function with_filter_state(StreamFilterState $filter_state = null): FilteredStreamCursor
+    public function with_filter_state(?StreamFilterState $filter_state = null): FilteredStreamCursor
     {
         return new self($this->cursor, $filter_state);
     }

--- a/lib/Tumblr/StreamBuilder/StreamCursors/InjectedStreamCursor.php
+++ b/lib/Tumblr/StreamBuilder/StreamCursors/InjectedStreamCursor.php
@@ -43,7 +43,7 @@ final class InjectedStreamCursor extends StreamCursor
      * @param StreamCursor $inner_cursor    The cursor for the inner stream.
      * @param array|null $injector_state    The injector state.
      */
-    public function __construct(StreamCursor $inner_cursor = null, array $injector_state = null)
+    public function __construct(?StreamCursor $inner_cursor = null, ?array $injector_state = null)
     {
         $this->inner_cursor = $inner_cursor;
         $this->injector_state = $injector_state;

--- a/lib/Tumblr/StreamBuilder/StreamCursors/MultiCursor.php
+++ b/lib/Tumblr/StreamBuilder/StreamCursors/MultiCursor.php
@@ -41,7 +41,7 @@ final class MultiCursor extends StreamCursor
      * @param array $stream_to_cursor Mapping from stream ids (strings) to StreamCursor objects
      * @param array|null $injector_state State of injector, if any.
      */
-    public function __construct(array $stream_to_cursor, array $injector_state = null)
+    public function __construct(array $stream_to_cursor, ?array $injector_state = null)
     {
         $this->stream_to_cursor = $stream_to_cursor;
         $this->injector_state = $injector_state;
@@ -115,7 +115,7 @@ final class MultiCursor extends StreamCursor
      * @param array|null $injector_state State of injector, if any.
      * @return MultiCursor
      */
-    public function with_injector_state(array $injector_state = null): self
+    public function with_injector_state(?array $injector_state = null): self
     {
         return new MultiCursor($this->stream_to_cursor, $injector_state);
     }

--- a/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursor.php
+++ b/lib/Tumblr/StreamBuilder/StreamCursors/StreamCursor.php
@@ -60,7 +60,7 @@ abstract class StreamCursor extends Templatable
      * @param StreamCursor|null $other The other cursor.
      * @return bool True, iff the cursors can combine.
      */
-    final public function can_combine_with(StreamCursor $other = null): bool
+    final public function can_combine_with(?StreamCursor $other = null): bool
     {
         return is_null($other) || $this->_can_combine_with($other);
     }
@@ -73,7 +73,7 @@ abstract class StreamCursor extends Templatable
      * @throws UncombinableCursorException If the provided cursor cannot be combined
      * with this cursor.
      */
-    final public function combine_with(StreamCursor $other = null): self
+    final public function combine_with(?StreamCursor $other = null): self
     {
         if (is_null($other)) {
             return $this;
@@ -158,7 +158,7 @@ abstract class StreamCursor extends Templatable
         string $secret,
         string $encrypt_key,
         string $initial_vector_seed = '',
-        CacheProvider $cache_provider = null,
+        ?CacheProvider $cache_provider = null,
         int $cache_size_threshold = self::DEFAULT_CACHE_SIZE_THRESHOLD,
         ?string $context = null,
         ?string $current_user_id = null
@@ -220,7 +220,7 @@ abstract class StreamCursor extends Templatable
         array $encrypt_keys,
         ?string $current_user_id = null,
         array $encrypt_seeds = [],
-        CacheProvider $cache_provider = null
+        ?CacheProvider $cache_provider = null
     ): ?self {
         if (empty(trim($cursor_string))) {
             return null;

--- a/lib/Tumblr/StreamBuilder/StreamFilterState.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilterState.php
@@ -34,7 +34,7 @@ abstract class StreamFilterState extends Templatable
      * @param StreamFilterState|null $other The other state.
      * @return bool True, iff the states can merge.
      */
-    final public function can_merge_with(StreamFilterState $other = null): bool
+    final public function can_merge_with(?StreamFilterState $other = null): bool
     {
         return is_null($other) || $this->_can_merge_with($other);
     }
@@ -52,7 +52,7 @@ abstract class StreamFilterState extends Templatable
      * @return StreamFilterState The combined state.
      * @throws UnmergeableFilterStateException If the provided state cannot be merged with this state.
      */
-    final public function merge_with(StreamFilterState $other = null): StreamFilterState
+    final public function merge_with(?StreamFilterState $other = null): StreamFilterState
     {
         if (is_null($other)) {
             return $this;

--- a/lib/Tumblr/StreamBuilder/StreamFilters/CachedStreamFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/CachedStreamFilter.php
@@ -139,7 +139,7 @@ final class CachedStreamFilter extends StreamFilter
     /**
      * @inheritDoc
      */
-    final public function filter_inner(array $elements, StreamFilterState $state = null, StreamTracer $tracer = null): StreamFilterResult
+    final public function filter_inner(array $elements, ?StreamFilterState $state = null, ?StreamTracer $tracer = null): StreamFilterResult
     {
         $key_to_index = [];
         $index_to_key = [];

--- a/lib/Tumblr/StreamBuilder/StreamFilters/ChronologicalRangeFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/ChronologicalRangeFilter.php
@@ -47,8 +47,8 @@ final class ChronologicalRangeFilter extends StreamElementFilter
      */
     public function __construct(
         string $identity,
-        int $max_timestamp_ms_inclusive = null,
-        int $min_timestamp_ms_exclusive = null,
+        ?int $max_timestamp_ms_inclusive = null,
+        ?int $min_timestamp_ms_exclusive = null,
         bool $release_non_chrono = false
     ) {
         if (is_null($max_timestamp_ms_inclusive) && is_null($min_timestamp_ms_exclusive)) {

--- a/lib/Tumblr/StreamBuilder/StreamFilters/CompositeStreamFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/CompositeStreamFilter.php
@@ -113,7 +113,7 @@ final class CompositeStreamFilter extends StreamFilter
     /**
      * @inheritDoc
      */
-    final public function filter_inner(array $elements, StreamFilterState $state = null, StreamTracer $tracer = null): StreamFilterResult
+    final public function filter_inner(array $elements, ?StreamFilterState $state = null, ?StreamTracer $tracer = null): StreamFilterResult
     {
         /** @var CompositeStreamFilterState $state */
         if (is_null($state)) {

--- a/lib/Tumblr/StreamBuilder/StreamFilters/DeduplicatedStreamFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/DeduplicatedStreamFilter.php
@@ -67,7 +67,7 @@ class DeduplicatedStreamFilter extends StreamFilter
     /**
      * @inheritDoc
      */
-    final public function filter_inner(array $elements, StreamFilterState $state = null, StreamTracer $tracer = null): StreamFilterResult
+    final public function filter_inner(array $elements, ?StreamFilterState $state = null, ?StreamTracer $tracer = null): StreamFilterResult
     {
         /** @var DeduplicatedStreamFilterState $state */
         if (is_null($state)) {

--- a/lib/Tumblr/StreamBuilder/StreamFilters/InverseFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/InverseFilter.php
@@ -93,7 +93,7 @@ final class InverseFilter extends StreamFilter
     /**
      * @inheritDoc
      */
-    final public function filter_inner(array $elements, StreamFilterState $state = null, StreamTracer $tracer = null): StreamFilterResult
+    final public function filter_inner(array $elements, ?StreamFilterState $state = null, ?StreamTracer $tracer = null): StreamFilterResult
     {
         return $this->inner->filter($elements, $state, $tracer)->get_inverse();
     }

--- a/lib/Tumblr/StreamBuilder/StreamFilters/NoopStreamFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/NoopStreamFilter.php
@@ -34,7 +34,7 @@ class NoopStreamFilter extends StreamFilter
     /**
      * @inheritDoc
      */
-    final public function filter_inner(array $elements, StreamFilterState $state = null, StreamTracer $tracer = null): StreamFilterResult
+    final public function filter_inner(array $elements, ?StreamFilterState $state = null, ?StreamTracer $tracer = null): StreamFilterResult
     {
         $retained = $elements;
         $released = [];

--- a/lib/Tumblr/StreamBuilder/StreamFilters/StreamElementFilter.php
+++ b/lib/Tumblr/StreamBuilder/StreamFilters/StreamElementFilter.php
@@ -34,7 +34,7 @@ abstract class StreamElementFilter extends StreamFilter
     /**
      * @inheritDoc
      */
-    final public function filter_inner(array $elements, StreamFilterState $state = null, StreamTracer $tracer = null): StreamFilterResult
+    final public function filter_inner(array $elements, ?StreamFilterState $state = null, ?StreamTracer $tracer = null): StreamFilterResult
     {
         $retained = [];
         $released = [];

--- a/lib/Tumblr/StreamBuilder/StreamInjectors/GeneralStreamInjector.php
+++ b/lib/Tumblr/StreamBuilder/StreamInjectors/GeneralStreamInjector.php
@@ -75,8 +75,8 @@ class GeneralStreamInjector extends StreamInjector
     protected function _plan_injection(
         int $page_size,
         Stream $requesting_stream,
-        array $state = null,
-        StreamTracer $tracer = null
+        ?array $state = null,
+        ?StreamTracer $tracer = null
     ): InjectionPlan {
         $allocate_result = $this->allocator->allocate($page_size, $state);
         $cursor = $this->cursorFromInjectionState($state ?? []);

--- a/lib/Tumblr/StreamBuilder/StreamInjectors/NoopInjector.php
+++ b/lib/Tumblr/StreamBuilder/StreamInjectors/NoopInjector.php
@@ -33,7 +33,7 @@ final class NoopInjector extends StreamInjector
     /**
      * @inheritDoc
      */
-    protected function _plan_injection(int $page_size, Stream $requesting_stream, array $state = null, StreamTracer $tracer = null): InjectionPlan
+    protected function _plan_injection(int $page_size, Stream $requesting_stream, ?array $state = null, ?StreamTracer $tracer = null): InjectionPlan
     {
         return new InjectionPlan([], null);
     }

--- a/lib/Tumblr/StreamBuilder/StreamInjectors/PrioritizedCompositeInjector.php
+++ b/lib/Tumblr/StreamBuilder/StreamInjectors/PrioritizedCompositeInjector.php
@@ -40,8 +40,8 @@ final class PrioritizedCompositeInjector extends CompositeStreamInjector
     protected function _plan_injection(
         int $page_size,
         Stream $requesting_stream,
-        array $state = null,
-        StreamTracer $tracer = null
+        ?array $state = null,
+        ?StreamTracer $tracer = null
     ): InjectionPlan {
         if (is_null($state)) {
             $state = [];

--- a/lib/Tumblr/StreamBuilder/StreamInjectors/SingleElementInjector.php
+++ b/lib/Tumblr/StreamBuilder/StreamInjectors/SingleElementInjector.php
@@ -53,8 +53,8 @@ abstract class SingleElementInjector extends StreamInjector
     protected function _plan_injection(
         int $page_size,
         Stream $requesting_stream,
-        array $state = null,
-        StreamTracer $tracer = null
+        ?array $state = null,
+        ?StreamTracer $tracer = null
     ): InjectionPlan {
         $allocate_result = $this->allocator->allocate($page_size, $state);
         $slots = $allocate_result->get_allocate_output();

--- a/lib/Tumblr/StreamBuilder/StreamInjectors/StreamInjector.php
+++ b/lib/Tumblr/StreamBuilder/StreamInjectors/StreamInjector.php
@@ -43,8 +43,8 @@ abstract class StreamInjector extends Templatable
     final public function plan_injection(
         int $page_size,
         Stream $requesting_stream,
-        array $state = null,
-        StreamTracer $tracer = null
+        ?array $state = null,
+        ?StreamTracer $tracer = null
     ): InjectionPlan {
         $t0 = microtime(true);
         if (!$this->can_inject()) {
@@ -88,8 +88,8 @@ abstract class StreamInjector extends Templatable
     abstract protected function _plan_injection(
         int $page_size,
         Stream $requesting_stream,
-        array $state = null,
-        StreamTracer $tracer = null
+        ?array $state = null,
+        ?StreamTracer $tracer = null
     ): InjectionPlan;
 
     /**

--- a/lib/Tumblr/StreamBuilder/StreamRankers/CappedPostRanker.php
+++ b/lib/Tumblr/StreamBuilder/StreamRankers/CappedPostRanker.php
@@ -70,7 +70,7 @@ class CappedPostRanker extends StreamRanker
     public function __construct(
         User $user,
         string $identity,
-        bool $debug = null,
+        ?bool $debug = null,
         bool $cap_desc,
         int $cap,
         string $ranking_context,
@@ -88,7 +88,7 @@ class CappedPostRanker extends StreamRanker
     /**
      * @inheritDoc
      */
-    protected function rank_inner(array $stream_elements, StreamTracer $tracer = null): array
+    protected function rank_inner(array $stream_elements, ?StreamTracer $tracer = null): array
     {
         if ($this->can_rank()) {
             return $this->apply_capped_reranking($stream_elements, $this->debug, $this->cap_desc, $this->cap);

--- a/lib/Tumblr/StreamBuilder/StreamRankers/DitheringRanker.php
+++ b/lib/Tumblr/StreamBuilder/StreamRankers/DitheringRanker.php
@@ -68,7 +68,7 @@ class DitheringRanker extends StreamRanker
     /**
      * @inheritDoc
      */
-    protected function rank_inner(array $stream_elements, StreamTracer $tracer = null): array
+    protected function rank_inner(array $stream_elements, ?StreamTracer $tracer = null): array
     {
         if (empty($stream_elements)) {
             return [];

--- a/lib/Tumblr/StreamBuilder/StreamRankers/RandomRanker.php
+++ b/lib/Tumblr/StreamBuilder/StreamRankers/RandomRanker.php
@@ -32,7 +32,7 @@ final class RandomRanker extends StreamRanker
     /**
      * @inheritDoc
      */
-    protected function rank_inner(array $stream_elements, StreamTracer $tracer = null): array
+    protected function rank_inner(array $stream_elements, ?StreamTracer $tracer = null): array
     {
         shuffle($stream_elements);
         return $stream_elements;

--- a/lib/Tumblr/StreamBuilder/StreamRankers/SignalFetcherStreamRanker.php
+++ b/lib/Tumblr/StreamBuilder/StreamRankers/SignalFetcherStreamRanker.php
@@ -49,7 +49,7 @@ abstract class SignalFetcherStreamRanker extends StreamRanker
     /**
      * @inheritDoc
      */
-    final protected function rank_inner(array $stream_elements, StreamTracer $tracer = null): array
+    final protected function rank_inner(array $stream_elements, ?StreamTracer $tracer = null): array
     {
         /** @var StreamElement[] $stream_elements */
         $signals = $this->signal_fetcher->fetch($stream_elements, $tracer);

--- a/lib/Tumblr/StreamBuilder/StreamRankers/StreamRanker.php
+++ b/lib/Tumblr/StreamBuilder/StreamRankers/StreamRanker.php
@@ -41,7 +41,7 @@ abstract class StreamRanker extends Templatable
      * @throws IllegalRankerException If the rank method adds or removes elements.
      * Also, rethrows \Exception if some other error occurs, but PHPCBF does not want me to document this.
      */
-    final public function rank(array $stream_elements, StreamTracer $tracer = null): array
+    final public function rank(array $stream_elements, ?StreamTracer $tracer = null): array
     {
         foreach ($stream_elements as $stream_element) {
             if (!($stream_element instanceof StreamElement)) {
@@ -83,7 +83,7 @@ abstract class StreamRanker extends Templatable
      * @param StreamTracer|null $tracer Tracer to use for metrics and logging of ranking process.
      * @return StreamElement[] Same elements as input, reranked. It is illegal to add or remove elements during this operation.
      */
-    abstract protected function rank_inner(array $stream_elements, StreamTracer $tracer = null): array;
+    abstract protected function rank_inner(array $stream_elements, ?StreamTracer $tracer = null): array;
 
     /**
      * A batch pre-fetch to inflate a set of stream elements or cache data need to be used in your ranker.

--- a/lib/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRanker.php
+++ b/lib/Tumblr/StreamBuilder/StreamRankers/WeightedRandomStreamRanker.php
@@ -34,7 +34,7 @@ class WeightedRandomStreamRanker extends StreamRanker
      * @inheritDoc
      * @psalm-suppress UndefinedDocblockClass
      */
-    protected function rank_inner(array $stream_elements, StreamTracer $tracer = null): array
+    protected function rank_inner(array $stream_elements, ?StreamTracer $tracer = null): array
     {
         // if there are no stream elements to rank, return early
         if (empty($stream_elements)) {

--- a/lib/Tumblr/StreamBuilder/Streams/BufferedRankedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/BufferedRankedStream.php
@@ -68,8 +68,8 @@ final class BufferedRankedStream extends Stream
      */
     public function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         if (is_null($cursor)) {

--- a/lib/Tumblr/StreamBuilder/Streams/CachedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/CachedStream.php
@@ -174,7 +174,7 @@ abstract class CachedStream extends WrapStream
     abstract protected function _slice_result_with_cursor(
         int $count,
         StreamResult $inner_result,
-        StreamCursor $cursor = null
+        ?StreamCursor $cursor = null
     ): StreamResult;
 
     /**

--- a/lib/Tumblr/StreamBuilder/Streams/ChronologicalBackfillStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ChronologicalBackfillStream.php
@@ -72,8 +72,8 @@ final class ChronologicalBackfillStream extends Stream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         /** @var MultiCursor $cursor */

--- a/lib/Tumblr/StreamBuilder/Streams/ChronologicalRangedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ChronologicalRangedStream.php
@@ -64,8 +64,8 @@ final class ChronologicalRangedStream extends WrapStream
      */
     final protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         $now = time();

--- a/lib/Tumblr/StreamBuilder/Streams/ConcatenatedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ConcatenatedStream.php
@@ -78,8 +78,8 @@ class ConcatenatedStream extends Stream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         // if this stream does not contain any stream, should return empty result

--- a/lib/Tumblr/StreamBuilder/Streams/CursorlessFilteredStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/CursorlessFilteredStream.php
@@ -120,8 +120,8 @@ final class CursorlessFilteredStream extends WrapStream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         return $this->_filter_rec($count, $cursor, $this->retry_count, $tracer, $option);
@@ -140,7 +140,7 @@ final class CursorlessFilteredStream extends WrapStream
         int $want_count,
         ?StreamCursor $inner_cursor,
         int $depth,
-        StreamTracer $tracer = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         $fetch_count = intval(ceil($want_count * (1.0 + max(0.0, $this->overfetch_ratio))));

--- a/lib/Tumblr/StreamBuilder/Streams/EquivalentStreamCombiner.php
+++ b/lib/Tumblr/StreamBuilder/Streams/EquivalentStreamCombiner.php
@@ -38,8 +38,8 @@ abstract class EquivalentStreamCombiner extends Stream
      */
     final protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         /** @var StreamResult $combined_result */
@@ -57,8 +57,8 @@ abstract class EquivalentStreamCombiner extends Stream
      */
     abstract protected function combine(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult;
 }

--- a/lib/Tumblr/StreamBuilder/Streams/FilteredStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/FilteredStream.php
@@ -87,8 +87,8 @@ final class FilteredStream extends WrapStream
         Stream $inner,
         StreamFilter $filter,
         string $identity,
-        int $retry_count = null,
-        float $overfetch_ratio = null,
+        ?int $retry_count = null,
+        ?float $overfetch_ratio = null,
         bool $skip_filters = false,
         bool $slice_result = true
     ) {
@@ -148,8 +148,8 @@ final class FilteredStream extends WrapStream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         /** @var FilteredStreamCursor $cursor */
@@ -184,7 +184,7 @@ final class FilteredStream extends WrapStream
         ?StreamCursor $inner_cursor,
         ?StreamFilterState $filter_state,
         int $depth,
-        StreamTracer $tracer = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         $fetch_count = intval(ceil($want_count * (1.0 + max(0.0, $this->overfetch_ratio))));

--- a/lib/Tumblr/StreamBuilder/Streams/InjectedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/InjectedStream.php
@@ -60,8 +60,8 @@ final class InjectedStream extends WrapStream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         if (is_null($cursor)) {

--- a/lib/Tumblr/StreamBuilder/Streams/NullStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/NullStream.php
@@ -36,8 +36,8 @@ final class NullStream extends Stream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         return new StreamResult(true, []);

--- a/lib/Tumblr/StreamBuilder/Streams/PrependedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/PrependedStream.php
@@ -95,8 +95,8 @@ class PrependedStream extends Stream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         $results = $this->after->enumerate($count, $cursor, $tracer, $option);

--- a/lib/Tumblr/StreamBuilder/Streams/ProportionalRoundRobinStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ProportionalRoundRobinStream.php
@@ -126,8 +126,8 @@ final class ProportionalRoundRobinStream extends Stream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         /** @var ProportionalRoundRobinStreamCursor $cursor */

--- a/lib/Tumblr/StreamBuilder/Streams/ProportionalStreamCombiner.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ProportionalStreamCombiner.php
@@ -123,7 +123,7 @@ final class ProportionalStreamCombiner extends StreamCombiner
     protected function combine(
         int $count,
         MultiCursor $cursor,
-        StreamTracer $tracer = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         // current map of feed ids we can draw from

--- a/lib/Tumblr/StreamBuilder/Streams/RankedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/RankedStream.php
@@ -53,8 +53,8 @@ final class RankedStream extends WrapStream
      */
     final protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         $res = $this->getInner()->enumerate($count, $cursor, $tracer, $option);

--- a/lib/Tumblr/StreamBuilder/Streams/SizeLimitedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/SizeLimitedStream.php
@@ -70,8 +70,8 @@ class SizeLimitedStream extends Stream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         if (is_null($cursor)) {

--- a/lib/Tumblr/StreamBuilder/Streams/Stream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/Stream.php
@@ -90,8 +90,8 @@ abstract class Stream extends Templatable implements StreamInterface
      */
     abstract protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult;
 

--- a/lib/Tumblr/StreamBuilder/Streams/StreamCombiner.php
+++ b/lib/Tumblr/StreamBuilder/Streams/StreamCombiner.php
@@ -39,8 +39,8 @@ abstract class StreamCombiner extends Stream
      */
     final protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         if (is_null($cursor)) {
@@ -82,7 +82,7 @@ abstract class StreamCombiner extends Stream
     abstract protected function combine(
         int $count,
         MultiCursor $cursor,
-        StreamTracer $tracer = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult;
 }

--- a/lib/Tumblr/StreamBuilder/Streams/StreamMixer.php
+++ b/lib/Tumblr/StreamBuilder/Streams/StreamMixer.php
@@ -61,8 +61,8 @@ abstract class StreamMixer extends Stream
      */
     final protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         if (is_null($cursor)) {

--- a/lib/Tumblr/StreamBuilder/Streams/TemplateReferenceStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/TemplateReferenceStream.php
@@ -63,8 +63,8 @@ class TemplateReferenceStream extends WrapStream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         return $this->getInner()->enumerate($count, $cursor, $tracer, $option);

--- a/tests/mock/tumblr/StreamBuilder/FencepostRanking/TestingFencepostProvider.php
+++ b/tests/mock/tumblr/StreamBuilder/FencepostRanking/TestingFencepostProvider.php
@@ -44,7 +44,7 @@ final class TestingFencepostProvider extends FencepostProvider
      */
     public function __construct(
         string $fence_id,
-        int $latest_timestamp_ms = null,
+        ?int $latest_timestamp_ms = null,
         array $fenceposts = []
     ) {
         $this->fence_id = $fence_id;

--- a/tests/mock/tumblr/StreamBuilder/StreamRankers/DummyStreamRanker.php
+++ b/tests/mock/tumblr/StreamBuilder/StreamRankers/DummyStreamRanker.php
@@ -33,7 +33,7 @@ final class DummyStreamRanker extends StreamRanker
     /**
      * @inheritDoc
      */
-    protected function rank_inner(array $stream_elements, StreamTracer $tracer = null): array
+    protected function rank_inner(array $stream_elements, ?StreamTracer $tracer = null): array
     {
         return $stream_elements;
     }

--- a/tests/mock/tumblr/StreamBuilder/StreamRankers/TestingRankableChronoStreamElementRanker.php
+++ b/tests/mock/tumblr/StreamBuilder/StreamRankers/TestingRankableChronoStreamElementRanker.php
@@ -34,7 +34,7 @@ final class TestingRankableChronoStreamElementRanker extends StreamRanker
     /**
      * @inheritDoc
      */
-    protected function rank_inner(array $stream_elements, StreamTracer $tracer = null): array
+    protected function rank_inner(array $stream_elements, ?StreamTracer $tracer = null): array
     {
         usort($stream_elements, function (TestingRankableChronoStreamElement $a, TestingRankableChronoStreamElement $b) {
             return $b->get_rank_ordinal() <=> $a->get_rank_ordinal();

--- a/tests/mock/tumblr/StreamBuilder/Streams/TestingRankableChronoStream.php
+++ b/tests/mock/tumblr/StreamBuilder/Streams/TestingRankableChronoStream.php
@@ -57,8 +57,8 @@ final class TestingRankableChronoStream extends Stream
      */
     protected function _enumerate(
         int $count,
-        StreamCursor $cursor = null,
-        StreamTracer $tracer = null,
+        ?StreamCursor $cursor = null,
+        ?StreamTracer $tracer = null,
         ?EnumerationOptions $option = null
     ): StreamResult {
         if (is_null($cursor)) {

--- a/tests/unit/Tumblr/StreamBuilder/FencepostRanking/FencepostRankedStreamTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/FencepostRanking/FencepostRankedStreamTest.php
@@ -92,7 +92,7 @@ class FencepostRankedStreamTest extends \PHPUnit\Framework\TestCase
         array $inner_elements,
         int $head_count,
         bool $rank_seed,
-        int $latest_fencepost_timestamp_ms = null,
+        ?int $latest_fencepost_timestamp_ms = null,
         array $next_timestamps = [],
         array $fenceposts = []
     ) {
@@ -123,7 +123,7 @@ class FencepostRankedStreamTest extends \PHPUnit\Framework\TestCase
         ?FencepostCursor $in_cursor,
         bool $should_exhaust,
         array $expected_elements,
-        FencepostCursor $expected_cursor = null
+        ?FencepostCursor $expected_cursor = null
     ) {
         $res = $stream->enumerate($count, $in_cursor);
         $this->assertEquals($should_exhaust, $res->is_exhaustive());

--- a/tests/unit/Tumblr/StreamBuilder/StreamCursors/BufferedCursorTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamCursors/BufferedCursorTest.php
@@ -44,7 +44,7 @@ class BufferedCursorTest extends \PHPUnit\Framework\TestCase
      * @param StreamCursor|null $cursor The cursor in the element.
      * @return StreamElement
      */
-    private function make_mock_element(string $provider_identity, StreamCursor $cursor = null): StreamElement
+    private function make_mock_element(string $provider_identity, ?StreamCursor $cursor = null): StreamElement
     {
         $m = $this->getMockBuilder(StreamElement::class)
             ->setConstructorArgs([ $provider_identity, $cursor ])

--- a/tests/unit/Tumblr/StreamBuilder/StreamCursors/FilteredStreamCursorTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamCursors/FilteredStreamCursorTest.php
@@ -190,7 +190,7 @@ class FilteredStreamCursorTest extends \PHPUnit\Framework\TestCase
      * @param StreamFilterState $state StreamFilterState.
      * @param StreamFilterState $expected_state The expected state.
      */
-    public function test_with_filter_state(StreamFilterState $state = null, StreamFilterState $expected_state = null)
+    public function test_with_filter_state(?StreamFilterState $state = null, ?StreamFilterState $expected_state = null)
     {
         $cursor = new FilteredStreamCursor();
         $cursor = $cursor->with_filter_state($state);

--- a/tests/unit/Tumblr/StreamBuilder/StreamInjectors/StreamInjectorTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/StreamInjectors/StreamInjectorTest.php
@@ -79,8 +79,8 @@ class StreamInjectorTest extends \PHPUnit\Framework\TestCase
             protected function _plan_injection(
                 int $page_size,
                 Stream $requesting_stream,
-                array $state = null,
-                StreamTracer $tracer = null
+                ?array $state = null,
+                ?StreamTracer $tracer = null
             ): InjectionPlan {
                 return InjectionPlan::create_empty_plan();
             }

--- a/tests/unit/Tumblr/StreamBuilder/Streams/ConcatenatedStreamTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/Streams/ConcatenatedStreamTest.php
@@ -98,7 +98,7 @@ class ConcatenatedStreamTest extends \PHPUnit\Framework\TestCase
         $this->stream_cursor2->expects($this->any())->method('_can_combine_with')->willReturn(true);
         // callback for enumerate function, which will return StreamResult based on passed in paramaters.
         // Because enumerate function is called by ConcatenatedStream so we can't do static return mock here.
-        $enumerate_callback = function ($count, StreamCursor $cursor = null) {
+        $enumerate_callback = function ($count, ?StreamCursor $cursor = null) {
             $offset = $cursor == null ? 0 : ($cursor == $this->stream_cursor1 ? 1 : 2);
             return new StreamResult($offset + $count >= 2, array_slice([$this->stream_element1, $this->stream_element2], $offset, $count));
         };

--- a/tests/unit/Tumblr/StreamBuilder/Streams/PrependedStreamTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/Streams/PrependedStreamTest.php
@@ -91,7 +91,7 @@ class PrependedStreamTest extends \PHPUnit\Framework\TestCase
         $this->stream_cursor2->expects($this->any())->method('_can_combine_with')->willReturn(true);
         // callback for enumerate function, which will return StreamResult based on passed in parameters.
         // Because enumerate function is called by ConcatenatedStream so we can't do static return mock here.
-        $enumerate_callback = function ($count, StreamCursor $cursor = null) {
+        $enumerate_callback = function ($count, ?StreamCursor $cursor = null) {
             $offset = $cursor == null ? 0 : ($cursor === $this->stream_cursor1 ? 1 : 2);
             return new StreamResult(
                 $offset + $count >= 2,

--- a/tests/unit/Tumblr/StreamBuilder/Streams/ProportionalRoundRobinStreamTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/Streams/ProportionalRoundRobinStreamTest.php
@@ -496,8 +496,8 @@ class ProportionalRoundRobinStreamTest extends \PHPUnit\Framework\TestCase
              */
             protected function _enumerate(
                 int $count,
-                StreamCursor $cursor = null,
-                StreamTracer $tracer = null,
+                ?StreamCursor $cursor = null,
+                ?StreamTracer $tracer = null,
                 ?EnumerationOptions $option = null
             ): StreamResult {
                 $slice = array_slice($this->elements, is_null($cursor) ? 0 : $cursor->index + 1, $count);


### PR DESCRIPTION
### What and why? 🤔

Let's start testing the library on PHP 8.4 and fix issues. Specifically, [implicit nullable are now deprecated as of PHP 8.4](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated):

```diff
- public function __construct(CacheProvider $cache_provider = null)
+ public function __construct(?CacheProvider $cache_provider = null)
```
Unless we make the change above, we'll see:
```
Deprecated:   Implicitly marking parameter $cache_provider as nullable is deprecated, the explicit nullable type must be used instead
```

This is a non-breaking change, as you can see from the lack of [LSP](https://en.wikipedia.org/wiki/Liskov_substitution_principle) errors: https://3v4l.org/VmME0

### Testing Steps ✍️

CI should pass, review the changes.


### You're it! 👑

Tag a random reviewer by adding `@Automattic/stream-builders` to the reviewers section, but mention them here for visibility as well.
