### PR TITLE
implement "can_enumerate" for streams that contain inner streams

### DIFF
--- a/lib/Tumblr/StreamBuilder/Streams/BufferedRankedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/BufferedRankedStream.php
@@ -135,6 +135,6 @@ final class BufferedRankedStream extends Stream
      */
     protected function can_enumerate(): bool
     {
-        return $this->inner->can_enumerate() && parent::can_enumerate();
+        return parent::can_enumerate() && $this->inner->can_enumerate();
     }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/BufferedRankedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/BufferedRankedStream.php
@@ -129,4 +129,12 @@ final class BufferedRankedStream extends Stream
             $context->get_cache_provider()
         );
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function can_enumerate(): bool
+    {
+        return $this->inner->can_enumerate() && parent::can_enumerate();
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/ChronologicalBackfillStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ChronologicalBackfillStream.php
@@ -170,4 +170,12 @@ final class ChronologicalBackfillStream extends Stream
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function can_enumerate(): bool
+    {
+        return parent::can_enumerate() && ($this->main_stream->can_enumerate() || $this->backfill_stream->can_enumerate());
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/ChronologicalStreamMixer.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ChronologicalStreamMixer.php
@@ -178,7 +178,7 @@ final class ChronologicalStreamMixer extends StreamMixer
         }
         foreach ($this->streams as $stream) {
             if ($stream->can_enumerate()) {
-                // as long as we can enumerate one stream, we can enumerate the concatenated stream.
+                // we need at least one inner stream to enumerate a mix.
                 return true;
             }
         }

--- a/lib/Tumblr/StreamBuilder/Streams/ChronologicalStreamMixer.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ChronologicalStreamMixer.php
@@ -167,4 +167,21 @@ final class ChronologicalStreamMixer extends StreamMixer
     {
         return true;
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function can_enumerate(): bool
+    {
+        if (!parent::can_enumerate()) {
+            return false;
+        }
+        foreach ($this->streams as $stream) {
+            if ($stream->can_enumerate()) {
+                // as long as we can enumerate one stream, we can enumerate the concatenated stream.
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/ConcatenatedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ConcatenatedStream.php
@@ -199,4 +199,21 @@ class ConcatenatedStream extends Stream
             }
         }
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function can_enumerate(): bool
+    {
+        if (!parent::can_enumerate()) {
+            return false;
+        }
+        foreach ($this->streams as $stream) {
+            if ($stream->can_enumerate()) {
+                // as long as we can enumerate one stream, we can enumerate the concatenated stream.
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/PrependedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/PrependedStream.php
@@ -154,4 +154,13 @@ class PrependedStream extends Stream
     {
         return $this->after->estimate_count();
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function can_enumerate(): bool
+    {
+        return parent::can_enumerate()
+            && ($this->before->can_enumerate() || $this->after->can_enumerate());
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/ProportionalRoundRobinStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ProportionalRoundRobinStream.php
@@ -257,6 +257,6 @@ final class ProportionalRoundRobinStream extends Stream
      */
     protected function can_enumerate(): bool
     {
-        return $this->major_stream->can_enumerate() && parent::can_enumerate();
+        return parent::can_enumerate() && $this->major_stream->can_enumerate();
     }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/ProportionalRoundRobinStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ProportionalRoundRobinStream.php
@@ -251,4 +251,12 @@ final class ProportionalRoundRobinStream extends Stream
             $context->get_current_identity()
         );
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function can_enumerate(): bool
+    {
+        return $this->major_stream->can_enumerate() && parent::can_enumerate();
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/ProportionalStreamCombiner.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ProportionalStreamCombiner.php
@@ -167,4 +167,23 @@ final class ProportionalStreamCombiner extends StreamCombiner
         // we are exhausted if the mixture became null
         return new StreamResult(is_null($current_mixture), $results);
     }
+
+    /**
+     * @return bool
+     */
+    protected function can_enumerate(): bool
+    {
+        if (!parent::can_enumerate()) {
+            return false;
+        }
+        foreach ($this->weights as $weight) {
+            $stream = $weight->get_stream();
+            if ($stream->can_enumerate()) {
+                // as long as at least one stream from the mix can be enumerated,
+                // the proportional stream combiner will be able to enumerate elements.
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/ProportionalStreamMixer.php
+++ b/lib/Tumblr/StreamBuilder/Streams/ProportionalStreamMixer.php
@@ -154,4 +154,23 @@ final class ProportionalStreamMixer extends StreamMixer
 
         return new StreamResult(empty($feeds), $results);
     }
+
+    /**
+     * @return bool
+     */
+    protected function can_enumerate(): bool
+    {
+        if (!parent::can_enumerate()) {
+            return false;
+        }
+        foreach ($this->weights as $weight) {
+            $stream = $weight->get_stream();
+            if ($stream->can_enumerate()) {
+                // as long as at least one stream from the mix can be enumerated,
+                // the proportional stream mixer will be able to enumerate elements.
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/RoundRobinStreamMixer.php
+++ b/lib/Tumblr/StreamBuilder/Streams/RoundRobinStreamMixer.php
@@ -178,6 +178,6 @@ abstract class RoundRobinStreamMixer extends StreamMixer
     #[\Override]
     protected function can_enumerate(): bool
     {
-        return $this->main->can_enumerate() && parent::can_enumerate();
+        return parent::can_enumerate() && $this->main->can_enumerate();
     }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/RoundRobinStreamMixer.php
+++ b/lib/Tumblr/StreamBuilder/Streams/RoundRobinStreamMixer.php
@@ -169,4 +169,12 @@ abstract class RoundRobinStreamMixer extends StreamMixer
      * @return int[] The position array.
      */
     abstract protected function get_main_stream_positions(int $count, ?StreamTracer $tracer = null): array;
+
+    /**
+     * @inheritDoc
+     */
+    protected function can_enumerate(): bool
+    {
+        return $this->main->can_enumerate() && parent::can_enumerate();
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/SizeLimitedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/SizeLimitedStream.php
@@ -152,6 +152,6 @@ class SizeLimitedStream extends Stream
     #[\Override]
     protected function can_enumerate(): bool
     {
-        return $this->stream->can_enumerate() && parent::can_enumerate();
+        return parent::can_enumerate() && $this->stream->can_enumerate();
     }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/SizeLimitedStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/SizeLimitedStream.php
@@ -142,4 +142,12 @@ class SizeLimitedStream extends Stream
                 ->warning('Trying to fetch posts from stream without setting the query string');
         }
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function can_enumerate(): bool
+    {
+        return $this->stream->can_enumerate() && parent::can_enumerate();
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/TemplateReferenceStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/TemplateReferenceStream.php
@@ -78,7 +78,7 @@ class TemplateReferenceStream extends WrapStream
     #[\Override]
     protected function can_enumerate(): bool
     {
-        return $this->getInner()->can_enumerate() && parent::can_enumerate();
+        return parent::can_enumerate() && $this->getInner()->can_enumerate();
     }
 
     /**

--- a/lib/Tumblr/StreamBuilder/Streams/TemplateReferenceStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/TemplateReferenceStream.php
@@ -73,6 +73,14 @@ class TemplateReferenceStream extends WrapStream
     /**
      * @inheritDoc
      */
+    protected function can_enumerate(): bool
+    {
+        return $this->getInner()->can_enumerate() && parent::can_enumerate();
+    }
+
+    /**
+     * @inheritDoc
+     */
     protected function can_enumerate_with_time_range(): bool
     {
         return $this->getInner()->can_enumerate_with_time_range();

--- a/lib/Tumblr/StreamBuilder/Streams/WrapStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/WrapStream.php
@@ -57,4 +57,12 @@ abstract class WrapStream extends Stream
         $base['inner'] = $this->getInner()->to_template();
         return $base;
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function can_enumerate(): bool
+    {
+        return $this->inner->can_enumerate() && parent::can_enumerate();
+    }
 }

--- a/lib/Tumblr/StreamBuilder/Streams/WrapStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/WrapStream.php
@@ -62,6 +62,7 @@ abstract class WrapStream extends Stream
     /**
      * @inheritDoc
      */
+    #[\Override]
     protected function can_enumerate(): bool
     {
         return parent::can_enumerate() && $this->inner->can_enumerate();

--- a/lib/Tumblr/StreamBuilder/Streams/WrapStream.php
+++ b/lib/Tumblr/StreamBuilder/Streams/WrapStream.php
@@ -64,6 +64,6 @@ abstract class WrapStream extends Stream
      */
     protected function can_enumerate(): bool
     {
-        return $this->inner->can_enumerate() && parent::can_enumerate();
+        return parent::can_enumerate() && $this->inner->can_enumerate();
     }
 }

--- a/tests/unit/Tumblr/StreamBuilder/Streams/CachedStreamTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/Streams/CachedStreamTest.php
@@ -121,6 +121,37 @@ class CachedStreamTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test when the inner stream returns false for `can_enumerate`,
+     * CachedStream returns empty results when enumerating, even when cache is hit.
+     */
+    public function testCacheHitCannotEnumerateInner()
+    {
+        $inner_stream = $this->getMockBuilder(Stream::class)
+            ->setConstructorArgs(['ello'])
+            ->getMockForAbstractClass();
+        $inner_stream->method('_enumerate')
+            ->willReturn(new StreamResult(false, []));
+        $inner_stream->method('can_enumerate')
+            ->willReturn(false);
+        $cache_provider = $this->getMockBuilder(CacheProvider::class)
+            ->getMock();
+        $cache_provider
+            ->expects($this->never())
+            ->method('set')
+            ->willReturn('');
+        $cache_provider
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn('sgnwjgnwj');
+        $stream = $this->getMockBuilder(CachedStream::class)
+            ->setConstructorArgs([$inner_stream, $cache_provider, 5, 10, 10, 'ello'])
+            ->getMock();
+        $stream->method('deserialize')
+            ->willReturn(new StreamResult(false, []));
+        $stream->enumerate(10);
+    }
+
+    /**
      * Test to_template
      */
     public function testToTemplate()

--- a/tests/unit/Tumblr/StreamBuilder/Streams/CachedStreamTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/Streams/CachedStreamTest.php
@@ -150,8 +150,9 @@ class CachedStreamTest extends \PHPUnit\Framework\TestCase
             ->expects($this->never())
             ->method('set')
             ->willReturn('');
+        // should not read from cache when "can_enumerate" returns false
         $cache_provider
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('get')
             ->willReturn('sgnwjgnwj');
         $stream = $this->getMockBuilder(CachedStream::class)

--- a/tests/unit/Tumblr/StreamBuilder/Streams/CachedStreamTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/Streams/CachedStreamTest.php
@@ -23,6 +23,7 @@ namespace Tests\Unit\Tumblr\StreamBuilder\Streams;
 
 use Test\Mock\Tumblr\StreamBuilder\StreamElements\MockedPostRefElement;
 use Tumblr\StreamBuilder\CacheProvider;
+use Tumblr\StreamBuilder\EnumerationOptions\EnumerationOptions;
 use Tumblr\StreamBuilder\StreamContext;
 use Tumblr\StreamBuilder\StreamCursors\StreamCursor;
 use Tumblr\StreamBuilder\StreamElements\StreamElement;
@@ -30,6 +31,7 @@ use Tumblr\StreamBuilder\StreamResult;
 use Tumblr\StreamBuilder\Streams\CachedStream;
 use Tumblr\StreamBuilder\Streams\NullStream;
 use Tumblr\StreamBuilder\Streams\Stream;
+use Tumblr\StreamBuilder\StreamTracers\StreamTracer;
 use Tumblr\StreamBuilder\TransientCacheProvider;
 
 /**

--- a/tests/unit/Tumblr/StreamBuilder/Streams/CachedStreamTest.php
+++ b/tests/unit/Tumblr/StreamBuilder/Streams/CachedStreamTest.php
@@ -132,13 +132,32 @@ class CachedStreamTest extends \PHPUnit\Framework\TestCase
     {
         // Create a test double for the inner stream that overrides can_enumerate
         $inner_stream = new class('ello') extends Stream {
-            protected function _enumerate(int $count, ?StreamCursor $cursor = null, ?StreamTracer $tracer = null, ?EnumerationOptions $option = null): StreamResult {
+            /**
+             * @inheritDoc
+             */
+            #[\Override]
+            protected function _enumerate(
+                int $count,
+                ?StreamCursor $cursor = null,
+                ?StreamTracer $tracer = null,
+                ?EnumerationOptions $option = null
+            ): StreamResult {
                 return new StreamResult(false, []);
             }
-            protected function can_enumerate(): bool {
+
+            /**
+             * @inheritDoc
+             */
+            #[\Override]
+            protected function can_enumerate(): bool
+            {
                 return false;
             }
 
+            /**
+             * @inheritDoc
+             */
+            #[\Override]
             public static function from_template(StreamContext $context)
             {
                 return new self($context->get_current_identity());


### PR DESCRIPTION
See: (issue #)

### What and why? 🤔

Some streams rely on inner streams. Those streams should implement `can_enumerate` based on the inner streams they contain.

We noticed that `CachedStream` would enumerate cached results, even when the inner stream returns false in `can_enumerate`.

When debugging the issue, we agreed that streams should rely on the inner's stream `can_enumerate` business logic to determine if the stream can enumerate itself. 


### Testing Steps ✍️

Unit tests should pass. 

### You're it! 👑

Tag a random reviewer by adding `@Automattic/stream-builders` to the reviewers section, but mention them here for visibility as well.
